### PR TITLE
Correct for absolute values to set_ctrl; issue #85

### DIFF
--- a/motioneye/v4l2ctl.py
+++ b/motioneye/v4l2ctl.py
@@ -287,7 +287,7 @@ def _get_ctrl(device, control):
     return value
 
 
-def _set_ctrl(device, control, value):
+def _set_ctrl(device, control, value, relative=True):
     global _ctrl_values_cache
     
     device = utils.make_str(device)
@@ -310,7 +310,8 @@ def _set_ctrl(device, control, value):
         min_value = int(properties['min'])
         max_value = int(properties['max'])
         
-        value = int(round(min_value + value * (max_value - min_value) / 100.0))
+        if relative:        
+            value = int(round(min_value + value * (max_value - min_value) / 100.0)) #only make up for relative values when appropriate
     
     else:
         logging.warn('min and max values not found for control %(control)s of device %(device)s' % {


### PR DESCRIPTION
When a value is set that is not relative (e.g. from slider) but absolute, just add the value
