### PR TITLE
Be able to save an image by right clicking (or long tap).

### DIFF
--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -1103,6 +1103,7 @@ div.camera-progress {
     transition: all 0.2s ease;
     text-align: center;
     cursor: pointer;
+    pointer-events: none;
 }
 
 div.camera-progress.visible {

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -3927,7 +3927,7 @@ function addCameraFrameUi(cameraConfig) {
     nameSpan.html(cameraConfig.name);
     progressImg.attr('src', staticPath + 'img/camera-progress.gif');
     
-    cameraProgress.click(function () {
+    cameraImg.click(function () {
         showCameraOverlay();
         overlayVisible = true;
     });


### PR DESCRIPTION
Right now, if you right click to try to locally save an image from a camera, it saves the progress loader instead. This change lets you click (or tap) and save a frame.