### PR TITLE
add checkboxes to individually control upload of pictures vs videos

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -635,6 +635,8 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         '@network_username': ui['network_username'],
         '@network_password': ui['network_password'],
         '@upload_enabled': ui['upload_enabled'],
+        '@upload_movie': ui['upload_movie'],
+        '@upload_picture': ui['upload_picture'],
         '@upload_service': ui['upload_service'],
         '@upload_server': ui['upload_server'],
         '@upload_port': ui['upload_port'],
@@ -973,6 +975,8 @@ def motion_camera_dict_to_ui(data):
         'disk_total': 0,
         'available_disks': diskctl.list_mounted_disks(),
         'upload_enabled': data['@upload_enabled'],
+        'upload_picture': data['@upload_picture'],
+        'upload_movie': data['@upload_movie'],
         'upload_service': data['@upload_service'],
         'upload_server': data['@upload_server'],
         'upload_port': data['@upload_port'],
@@ -1726,6 +1730,8 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@network_password', '')
     data.setdefault('target_dir', settings.MEDIA_PATH)
     data.setdefault('@upload_enabled', False)
+    data.setdefault('@upload_picture', True)
+    data.setdefault('@upload_movie', True)
     data.setdefault('@upload_service', 'ftp')
     data.setdefault('@upload_server', '')
     data.setdefault('@upload_port', '')

--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -1578,14 +1578,14 @@ class RelayEventHandler(BaseHandler):
                     camera_config=camera_config, full_path=filename)
 
             # upload to external service
-            if camera_config['@upload_enabled']:
+            if camera_config['@upload_enabled'] and camera_config['@upload_movie']:
                 self.upload_media_file(filename, camera_id, camera_config)
 
         elif event == 'picture_save':
             filename = self.get_argument('filename')
             
             # upload to external service
-            if camera_config['@upload_enabled']:
+            if camera_config['@upload_enabled'] and camera_config['@upload_picture']:
                 self.upload_media_file(filename, camera_id, camera_config)
 
         else:

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1486,6 +1486,8 @@ function cameraUi2Dict() {
         'network_password': $('#networkPasswordEntry').val(),
         'root_directory': $('#rootDirectoryEntry').val(),
         'upload_enabled': $('#uploadEnabledSwitch')[0].checked,
+        'upload_picture': $('#uploadPictureSwitch')[0].checked,
+        'upload_movie': $('#uploadMovieSwitch')[0].checked,
         'upload_service': $('#uploadServiceSelect').val(),
         'upload_server': $('#uploadServerEntry').val(),
         'upload_port': $('#uploadPortEntry').val(),
@@ -1779,6 +1781,8 @@ function dict2CameraUi(dict) {
     }); markHideIfNull('disk_used', 'diskUsageProgressBar');
     
     $('#uploadEnabledSwitch')[0].checked = dict['upload_enabled']; markHideIfNull('upload_enabled', 'uploadEnabledSwitch');
+    $('#uploadPictureSwitch')[0].checked = dict['upload_picture']; markHideIfNull('upload_picture', 'uploadPictureSwitch');
+    $('#uploadMovieSwitch')[0].checked = dict['upload_movie']; markHideIfNull('upload_movie', 'uploadMovieSwitch');
     $('#uploadServiceSelect').val(dict['upload_service']); markHideIfNull('upload_service', 'uploadServiceSelect');
     $('#uploadServerEntry').val(dict['upload_server']); markHideIfNull('upload_server', 'uploadServerEntry');
     $('#uploadPortEntry').val(dict['upload_port']); markHideIfNull('upload_port', 'uploadPortEntry');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -371,6 +371,16 @@
                         <td><span class="help-mark" title="enable this if you want your media files to be uploaded to an external service">?</span></td>
                     </tr>
                     <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Upload Pictures</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="uploadPictureSwitch"></td>
+                        <td><span class="help-mark" title="enable this if you want single frame pictures to be uploaded to an external service">?</span></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Upload Movies</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="uploadMovieSwitch"></td>
+                        <td><span class="help-mark" title="enable this if you want videos to be uploaded to an external service">?</span></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" depends="uploadEnabled">
                         <td class="settings-item-label"><span class="settings-item-label">Upload Service</span></td>
                         <td class="settings-item-value">
                             <select class="styled storage camera-config" id="uploadServiceSelect">


### PR DESCRIPTION
This adds the ability to enable file uploading of only certain types of files (photos or movies). The default configuration is to upload both types, which is what motioneye currently does.

This functionality might be especially useful for people that only want to upload one type, but still capture both types locally for reconstruction purposes.

![upload-types](https://cloud.githubusercontent.com/assets/101175/14659986/48848d38-0666-11e6-8eda-12385ebf5768.png)
