### PR TITLE
Add "event_end" treatment in the user inteface

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -913,6 +913,9 @@ def motion_camera_ui_to_dict(ui, old_config=None):
 
     # event end
     on_event_end = ['%(script)s stop %%t' % {'script': meyectl.find_command('relayevent')}]
+
+    if ui['command_post_notifications_enabled']:
+        on_event_end += utils.split_semicolon(ui['command_post_notifications_exec'])
     
     data['on_event_end'] = '; '.join(on_event_end)
     
@@ -1053,6 +1056,7 @@ def motion_camera_dict_to_ui(data):
         'email_notifications_enabled': False,
         'web_hook_notifications_enabled': False,
         'command_notifications_enabled': False,
+        'command_post_notifications_enabled': False,
         
         # working schedule
         'working_schedule': False,
@@ -1296,6 +1300,24 @@ def motion_camera_dict_to_ui(data):
     if command_notifications: 
         ui['command_notifications_enabled'] = True
         ui['command_notifications_exec'] = '; '.join(command_notifications)
+
+    # event end
+    on_event_end = data.get('on_event_end') or []
+    if on_event_end:
+        on_event_end = utils.split_semicolon(on_event_end)
+
+    command_post_notifications = []
+    for e in on_event_end:
+        if e.count('relayevent') or e.count('eventrelay.py'):
+            continue # ignore internal relay script
+
+        else: # custom command
+            command_post_notifications.append(e)
+
+    if command_post_notifications:
+        ui['command_post_notifications_enabled'] = True
+        ui['command_post_notifications_exec'] = '; '.join(command_post_notifications)
+
 
     # movie end
     on_movie_end = data.get('on_movie_end') or []

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1570,6 +1570,8 @@ function cameraUi2Dict() {
         'web_hook_notifications_http_method': $('#webHookNotificationsHttpMethodSelect').val(),
         'command_notifications_enabled': $('#commandNotificationsEnabledSwitch')[0].checked,
         'command_notifications_exec': $('#commandNotificationsEntry').val(),
+        'command_post_notifications_enabled': $('#commandPostNotificationsEnabledSwitch')[0].checked,
+        'command_post_notifications_exec': $('#commandPostNotificationsEntry').val(),
         
         /* working schedule */
         'working_schedule': $('#workingScheduleEnabledSwitch')[0].checked,
@@ -1912,6 +1914,8 @@ function dict2CameraUi(dict) {
     
     $('#commandNotificationsEnabledSwitch')[0].checked = dict['command_notifications_enabled']; markHideIfNull('command_notifications_enabled', 'commandNotificationsEnabledSwitch');
     $('#commandNotificationsEntry').val(dict['command_notifications_exec']);
+    $('#commandPostNotificationsEnabledSwitch')[0].checked = dict['command_post_notifications_enabled']; markHideIfNull('command_post_notifications_enabled', 'commandPostNotificationsEnabledSwitch');
+    $('#commandPostNotificationsEntry').val(dict['command_post_notifications_exec']);
 
     /* working schedule */
     $('#workingScheduleEnabledSwitch')[0].checked = dict['working_schedule']; markHideIfNull('working_schedule', 'workingScheduleEnabledSwitch');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -912,6 +912,19 @@
                         <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="commandNotificationsEntry" placeholder="command..."></td>
                         <td><span class="help-mark" title="a command to be executed when motion is detected; multiple commands can be separated by a semicolon; don't use semilcolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = date, %H = hour, %M = minute, %S = second, %q = frame number">?</span></td>
                     </tr>
+                    <tr class="settings-item advanced-setting" depends="motionDetectionEnabled">
+                        <td colspan="100"><div class="settings-item-separator"></div></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" depends="motionDetectionEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Run A Post Command</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled notifications camera-config" id="commandPostNotificationsEnabledSwitch"></td>
+                        <td><span class="help-mark" title="enable this if you want to execute a command whenever a motion event is finished">?</span></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" required="true" depends="commandPostNotificationsEnabled motionDetectionEnabled" strip="true">
+                        <td class="settings-item-label"><span class="settings-item-label">Command</span></td>
+                        <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="commandPostNotificationsEntry" placeholder="command..."></td>
+                        <td><span class="help-mark" title="a command to be executed when motion event is finished; multiple commands can be separated by a semicolon; don't use semilcolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = date, %H = hour, %M = minute, %S = second, %q = frame number">?</span></td>
+                    </tr>
                     {% for config in camera_sections.get('notifications', {}).get('configs', []) %}
                         {{config_item(config, "motionDetectionEnabled")}}
                     {% endfor %}


### PR DESCRIPTION
These changes allow the user to trigger an action when an event ends. It will be useful when it is needed to treat start and end of an event in different ways. 
