### PR TITLE
accept zero value motion gap

### DIFF
--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -834,7 +834,7 @@
                     <tr class="settings-item advanced-setting">
                         <td colspan="100"><div class="settings-item-separator"></div></td>
                     </tr>
-                    <tr class="settings-item advanced-setting" min="1" max="86400" required="true">
+                    <tr class="settings-item advanced-setting" min="0" max="86400" required="true">
                         <td class="settings-item-label"><span class="settings-item-label">Motion Gap</span></td>
                         <td class="settings-item-value"><input type="text" class="number styled motion-detection camera-config" id="eventGapEntry"><span class="settings-item-unit">seconds</span></td>
                         <td><span class="help-mark" title="sets the number of seconds of silence (i.e. no motion) that mark the end of a motion event">?</span></td>


### PR DESCRIPTION
Allow event gap to be set to zero to run in gapless mode.

Event Gap description from motion config file.

    Event Gap is the seconds of no motion detection that triggers the end of an event.
    An event is defined as a series of motion images taken within a short timeframe.
    Recommended value is 60 seconds (Default). The value -1 is allowed and disables
    events causing all Motion to be written to one single movie file and no pre_capture.
    If set to 0, motion is running in gapless mode. Movies don't have gaps anymore. An
    event ends right after no more motion is detected and post_capture is over.
