### PR TITLE
Fixed regex pattern for extracting username from /proc/mounts

### DIFF
--- a/motioneye/smbctl.py
+++ b/motioneye/smbctl.py
@@ -94,7 +94,7 @@ def list_mounts():
             server, share = match.groups()
             share = share.replace('\\040', ' ') # spaces are reported oddly by /proc/mounts
             
-            match = re.search('username=([\w\s]+)', opts)
+            match = re.search('username=([a-z][-\w]*)', opts)
             if match:
                 username = match.group(1)
             


### PR DESCRIPTION
The previous pattern truncated a valid username which contained a hyphen (not as the first character) which resulted in MotionEye repeatedly try to unmount a "no longer necessary" mount point which didn't exist.  The end result was that the live preview video switched to the "No Camera" icon, no live preview was showing on the web interface, and no still images nor motion detected movies were being stored in the Network Storage folder.

The previous pattern of "[\w\s]+" (1 or more occurrence of alpha, number, underscore, or any white space) seemed incorrect to me... though I'm not as familiar with non-Linux usernames nor what restrictions exist for usernames in CIFS mounting.  I simply used the default NAME_REGEX pattern specified in /usr/share/adduser/adduser.conf

See github issue #356 (https://github.com/ccrisan/motioneyeos/issues/356) and the follow-up google forums post (https://groups.google.com/forum/#!topic/motioneye/0Cve8obKAX8) for more history on this issue.