### PR TITLE
Manual Snapshot Support

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -770,8 +770,8 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         # still images
         'output_pictures': False,
         'snapshot_interval': 0,
-        'picture_filename': ui['image_file_name'],
-        'snapshot_filename': ui['image_file_name'],
+        'picture_filename': '',
+        'snapshot_filename': '',
         'quality': max(1, int(ui['image_quality'])),
         '@preserve_pictures': int(ui['preserve_pictures']),
         '@manual_snapshots': ui['manual_snapshots'],
@@ -940,6 +940,9 @@ def motion_camera_ui_to_dict(ui, old_config=None):
             data['text_double'] = True
 
     if ui['still_images']:
+        data['picture_filename'] = ui['image_file_name']
+        data['snapshot_filename'] = ui['image_file_name']
+
         capture_mode = ui['capture_mode']
         if capture_mode == 'motion-triggered':
             data['output_pictures'] = True
@@ -950,6 +953,10 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         elif capture_mode == 'all-frames':
             data['output_pictures'] = True
             data['emulate_motion'] = True
+
+        elif capture_mode == 'manual':
+            data['output_pictures'] = False
+            data['emulate_motion'] = False
 
     if ui['movies']:
         data['ffmpeg_output_movies'] = True
@@ -1340,8 +1347,7 @@ def motion_camera_dict_to_ui(data):
     snapshot_interval = data['snapshot_interval']
     snapshot_filename = data['snapshot_filename']
 
-    ui['still_images'] = (((emulate_motion or output_pictures) and picture_filename) or
-                          (snapshot_interval and snapshot_filename))
+    ui['still_images'] = bool(snapshot_filename) or bool(picture_filename)
 
     if emulate_motion:
         ui['capture_mode'] = 'all-frames'
@@ -1358,6 +1364,11 @@ def motion_camera_dict_to_ui(data):
         ui['capture_mode'] = 'motion-triggered'
         if picture_filename:
             ui['image_file_name'] = picture_filename
+
+    else:  # assuming manual
+        ui['capture_mode'] = 'manual'
+        if snapshot_filename:
+            ui['image_file_name'] = snapshot_filename
 
     if data['ffmpeg_output_movies']:
         ui['movies'] = True

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -770,8 +770,8 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         # still images
         'output_pictures': False,
         'snapshot_interval': 0,
-        'picture_filename': '',
-        'snapshot_filename': '',
+        'picture_filename': ui['image_file_name'],
+        'snapshot_filename': ui['image_file_name'],
         'quality': max(1, int(ui['image_quality'])),
         '@preserve_pictures': int(ui['preserve_pictures']),
 
@@ -942,16 +942,13 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         capture_mode = ui['capture_mode']
         if capture_mode == 'motion-triggered':
             data['output_pictures'] = True
-            data['picture_filename'] = ui['image_file_name']
 
         elif capture_mode == 'interval-snapshots':
             data['snapshot_interval'] = int(ui['snapshot_interval'])
-            data['snapshot_filename'] = ui['image_file_name']
 
         elif capture_mode == 'all-frames':
             data['output_pictures'] = True
             data['emulate_motion'] = True
-            data['picture_filename'] = ui['image_file_name']
 
     if ui['movies']:
         data['ffmpeg_output_movies'] = True

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -947,6 +947,9 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         if capture_mode == 'motion-triggered':
             data['output_pictures'] = True
 
+        elif capture_mode == 'motion-triggered-one':
+            data['output_pictures'] = 'best'
+
         elif capture_mode == 'interval-snapshots':
             data['snapshot_interval'] = int(ui['snapshot_interval'])
 
@@ -1361,7 +1364,12 @@ def motion_camera_dict_to_ui(data):
             ui['image_file_name'] = snapshot_filename
 
     elif output_pictures:
-        ui['capture_mode'] = 'motion-triggered'
+        if output_pictures == 'best':
+            ui['capture_mode'] = 'motion-triggered-one'
+
+        else:
+            ui['capture_mode'] = 'motion-triggered'
+
         if picture_filename:
             ui['image_file_name'] = picture_filename
 

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1045,8 +1045,8 @@ def motion_camera_ui_to_dict(ui, old_config=None):
     # event end
     on_event_end = ['%(script)s stop %%t' % {'script': meyectl.find_command('relayevent')}]
 
-    if ui['command_post_notifications_enabled']:
-        on_event_end += utils.split_semicolon(ui['command_post_notifications_exec'])
+    if ui['command_end_notifications_enabled']:
+        on_event_end += utils.split_semicolon(ui['command_end_notifications_exec'])
     
     data['on_event_end'] = '; '.join(on_event_end)
 
@@ -1193,7 +1193,7 @@ def motion_camera_dict_to_ui(data):
         'email_notifications_enabled': False,
         'web_hook_notifications_enabled': False,
         'command_notifications_enabled': False,
-        'command_post_notifications_enabled': False,
+        'command_end_notifications_enabled': False,
         
         # working schedule
         'working_schedule': False,
@@ -1472,18 +1472,17 @@ def motion_camera_dict_to_ui(data):
     if on_event_end:
         on_event_end = utils.split_semicolon(on_event_end)
 
-    command_post_notifications = []
+    command_end_notifications = []
     for e in on_event_end:
         if e.count('relayevent') or e.count('eventrelay.py'):
-            continue # ignore internal relay script
+            continue  # ignore internal relay script
 
-        else: # custom command
-            command_post_notifications.append(e)
+        else:  # custom command
+            command_end_notifications.append(e)
 
-    if command_post_notifications:
-        ui['command_post_notifications_enabled'] = True
-        ui['command_post_notifications_exec'] = '; '.join(command_post_notifications)
-
+    if command_end_notifications:
+        ui['command_end_notifications_enabled'] = True
+        ui['command_end_notifications_exec'] = '; '.join(command_end_notifications)
 
     # movie end
     on_movie_end = data.get('on_movie_end') or []

--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -1646,17 +1646,17 @@ class ActionHandler(BaseHandler):
 
         if action == 'snapshot':
             logging.debug('executing snapshot action for camera with id %s' % camera_id)
-            return self.snapshot()
+            return self.snapshot(camera_id)
         
         elif action == 'record_start':
             logging.debug('executing record_start action for camera with id %s' % camera_id)
-            return self.record_start()
+            return self.record_start(camera_id)
         
         elif action == 'record_stop':
             logging.debug('executing record_stop action for camera with id %s' % camera_id)
-            return self.record_stop()
+            return self.record_stop(camera_id)
 
-        action_commands = config.get_action_commands(camera_id)
+        action_commands = config.get_action_commands(local_config)
         command = action_commands.get(action)
         if not command:
             raise HTTPError(400, 'unknown action')
@@ -1694,13 +1694,14 @@ class ActionHandler(BaseHandler):
         else:
             self.io_loop.add_timeout(datetime.timedelta(milliseconds=100), self.check_command)
     
-    def snapshot(self):
+    def snapshot(self, camera_id):
+        motionctl.take_snapshot(camera_id)
         self.finish_json({})
     
-    def record_start(self):
+    def record_start(self, camera_id):
         self.finish_json({})
     
-    def record_stop(self):
+    def record_stop(self, camera_id):
         self.finish_json({})
 
 

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -212,11 +212,8 @@ def cleanup_media(media_type):
         if preserve_media == 0:
             continue  # preserve forever
         
-        still_images_enabled = bool(
-                ((camera_config['emulate_motion'] or camera_config['output_pictures']) and camera_config['picture_filename']) or
-                (camera_config['snapshot_interval'] and camera_config['snapshot_filename']))
-        
-        movies_enabled = camera_config['ffmpeg_output_movies']
+        still_images_enabled = bool(camera_config['picture_filename']) or bool(camera_config['snapshot_filename'])
+        movies_enabled = bool(camera_config['ffmpeg_output_movies'])
 
         if media_type == 'picture' and not still_images_enabled:
             continue  # only cleanup pictures for cameras with still images enabled

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1878,6 +1878,7 @@ function cameraUi2Dict() {
         'capture_mode': $('#captureModeSelect').val(),
         'snapshot_interval': $('#snapshotIntervalEntry').val(),
         'preserve_pictures': $('#preservePicturesSelect').val() >= 0 ? $('#preservePicturesSelect').val() : $('#picturesLifetimeEntry').val(),
+        'manual_snapshots': $('#manualSnapshotsSwitch')[0].checked,
         
         /* movies */
         'movies': $('#moviesEnabledSwitch')[0].checked,
@@ -2230,6 +2231,7 @@ function dict2CameraUi(dict) {
     }
     markHideIfNull('preserve_pictures', 'preservePicturesSelect');
     $('#picturesLifetimeEntry').val(dict['preserve_pictures']); markHideIfNull('preserve_pictures', 'picturesLifetimeEntry');
+    $('#manualSnapshotsSwitch')[0].checked = dict['manual_snapshots']; markHideIfNull('manual_snapshots', 'manualSnapshotsSwitch');
     
     /* movies */
     $('#moviesEnabledSwitch')[0].checked = dict['movies']; markHideIfNull('movies', 'moviesEnabledSwitch');

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1921,8 +1921,8 @@ function cameraUi2Dict() {
         'web_hook_notifications_http_method': $('#webHookNotificationsHttpMethodSelect').val(),
         'command_notifications_enabled': $('#commandNotificationsEnabledSwitch')[0].checked,
         'command_notifications_exec': $('#commandNotificationsEntry').val(),
-        'command_post_notifications_enabled': $('#commandPostNotificationsEnabledSwitch')[0].checked,
-        'command_post_notifications_exec': $('#commandPostNotificationsEntry').val(),
+        'command_end_notifications_enabled': $('#commandEndNotificationsEnabledSwitch')[0].checked,
+        'command_end_notifications_exec': $('#commandEndNotificationsEntry').val(),
         
         /* working schedule */
         'working_schedule': $('#workingScheduleEnabledSwitch')[0].checked,
@@ -2280,8 +2280,8 @@ function dict2CameraUi(dict) {
     
     $('#commandNotificationsEnabledSwitch')[0].checked = dict['command_notifications_enabled']; markHideIfNull('command_notifications_enabled', 'commandNotificationsEnabledSwitch');
     $('#commandNotificationsEntry').val(dict['command_notifications_exec']);
-    $('#commandPostNotificationsEnabledSwitch')[0].checked = dict['command_post_notifications_enabled']; markHideIfNull('command_post_notifications_enabled', 'commandPostNotificationsEnabledSwitch');
-    $('#commandPostNotificationsEntry').val(dict['command_post_notifications_exec']);
+    $('#commandEndNotificationsEnabledSwitch')[0].checked = dict['command_end_notifications_enabled']; markHideIfNull('command_end_notifications_enabled', 'commandEndNotificationsEnabledSwitch');
+    $('#commandEndNotificationsEntry').val(dict['command_end_notifications_exec']);
 
     /* working schedule */
     $('#workingScheduleEnabledSwitch')[0].checked = dict['working_schedule']; markHideIfNull('working_schedule', 'workingScheduleEnabledSwitch');

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -791,7 +791,7 @@ function initUI() {
     });
     
     /* capture mode and recording mode are not completely independent:
-     * all frames capture mode implies continuous recording (and vice-versa) */
+     * all-frames capture mode implies continuous recording (and vice-versa) */
     $('#captureModeSelect').change(function (val) {
         if ($('#captureModeSelect').val() == 'all-frames') {
             $('#recordingModeSelect').val('continuous');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -693,9 +693,14 @@
                                 <option value="motion-triggered">Motion Triggered</option>
                                 <option value="interval-snapshots">Interval Snapshots</option>
                                 <option value="all-frames">All Frames</option>
+                                <option value="manual">Manual</option>
                             </select>
                         </td>
-                        <td><span class="help-mark" title="sets the image capture mode: Motion Triggered = an image captured whenever motion is detected, Interval Snapshots = an image captured every x seconds, All Frames = saves each frame to an image file">?</span></td>
+                        <td><span class="help-mark" title="sets the image capture mode:
+                                Motion Triggered = an image captured whenever motion is detected,
+                                Interval Snapshots = an image captured every x seconds,
+                                All Frames = saves each frame to an image file,
+                                Manual = manual snapshots using snapshot button">?</span></td>
                     </tr>
                     <tr class="settings-item advanced-setting" min="1" max="86400" required="true" depends="captureMode=interval-snapshots">
                         <td class="settings-item-label"><span class="settings-item-label">Snapshot Interval</span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -691,6 +691,7 @@
                         <td class="settings-item-value">
                             <select class="styled still-images camera-config" id="captureModeSelect">
                                 <option value="motion-triggered">Motion Triggered</option>
+                                <option value="motion-triggered-one">Motion Triggered (One Picture)</option>
                                 <option value="interval-snapshots">Interval Snapshots</option>
                                 <option value="all-frames">All Frames</option>
                                 <option value="manual">Manual</option>
@@ -727,7 +728,7 @@
                         <td><span class="help-mark" title="sets the number of days after which the pictures will be deleted automatically">?</span></td>
                     </tr>
                     <tr class="settings-item advanced-setting">
-                        <td class="settings-item-label"><span class="settings-item-label">Manual Snapshots</span></td>
+                        <td class="settings-item-label"><span class="settings-item-label">Enable Manual Snapshots</span></td>
                         <td class="settings-item-value"><input type="checkbox" class="styled still-images camera-config" id="manualSnapshotsSwitch"></td>
                         <td><span class="help-mark" title="when this is enabled, a button on the camera frame will allow you to manually take snapshots">?</span></td>
                     </tr>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -1005,20 +1005,20 @@
                     <tr class="settings-item advanced-setting" required="true" depends="commandNotificationsEnabled motionDetectionEnabled" strip="true">
                         <td class="settings-item-label"><span class="settings-item-label">Command</span></td>
                         <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="commandNotificationsEntry" placeholder="command..."></td>
-                        <td><span class="help-mark" title="a command to be executed when motion is detected; multiple commands can be separated by a semicolon; don't use semilcolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number">?</span></td>
+                        <td><span class="help-mark" title="a command to be executed when motion is detected; multiple commands can be separated by a semicolon; don't use semicolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number">?</span></td>
                     </tr>
                     <tr class="settings-item advanced-setting" depends="motionDetectionEnabled">
                         <td colspan="100"><div class="settings-item-separator"></div></td>
                     </tr>
                     <tr class="settings-item advanced-setting" depends="motionDetectionEnabled">
-                        <td class="settings-item-label"><span class="settings-item-label">Run A Post Command</span></td>
-                        <td class="settings-item-value"><input type="checkbox" class="styled notifications camera-config" id="commandPostNotificationsEnabledSwitch"></td>
-                        <td><span class="help-mark" title="enable this if you want to execute a command whenever a motion event is finished">?</span></td>
+                        <td class="settings-item-label"><span class="settings-item-label">Run An End Command</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled notifications camera-config" id="commandEndNotificationsEnabledSwitch"></td>
+                        <td><span class="help-mark" title="enable this if you want to execute a command whenever a motion event ends">?</span></td>
                     </tr>
-                    <tr class="settings-item advanced-setting" required="true" depends="commandPostNotificationsEnabled motionDetectionEnabled" strip="true">
+                    <tr class="settings-item advanced-setting" required="true" depends="commandEndNotificationsEnabled motionDetectionEnabled" strip="true">
                         <td class="settings-item-label"><span class="settings-item-label">Command</span></td>
-                        <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="commandPostNotificationsEntry" placeholder="command..."></td>
-                        <td><span class="help-mark" title="a command to be executed when motion event is finished; multiple commands can be separated by a semicolon; don't use semilcolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = date, %H = hour, %M = minute, %S = second, %q = frame number">?</span></td>
+                        <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="commandEndNotificationsEntry" placeholder="command..."></td>
+                        <td><span class="help-mark" title="a command to be executed when motion event ends; multiple commands can be separated by a semicolon; don't use semicolons inside commands; the following special tokens are accepted: %Y = year, %m = month, %d = date, %H = hour, %M = minute, %S = second, %q = frame number">?</span></td>
                     </tr>
                     {% for config in camera_sections.get('notifications', {}).get('configs', []) %}
                         {{config_item(config, "motionDetectionEnabled")}}

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -721,6 +721,11 @@
                         <td class="settings-item-value"><input type="text" class="styled number still-images camera-config" id="picturesLifetimeEntry"><span class="settings-item-unit">days</span></td>
                         <td><span class="help-mark" title="sets the number of days after which the pictures will be deleted automatically">?</span></td>
                     </tr>
+                    <tr class="settings-item advanced-setting">
+                        <td class="settings-item-label"><span class="settings-item-label">Manual Snapshots</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled still-images camera-config" id="manualSnapshotsSwitch"></td>
+                        <td><span class="help-mark" title="when this is enabled, a button on the camera frame will allow you to manually take snapshots">?</span></td>
+                    </tr>
                     {% for config in camera_sections.get('still-images', {}).get('configs', []) %}
                         {{config_item(config)}}
                     {% endfor %}


### PR DESCRIPTION
This PR:
 * adds a snapshot button on the camera frame, allowing the user to manually take a snapshot
 * adds an "Enable Manual Snapshot" camera option that shows or hides the manual snapshot button
 * adds a "Manual" still images capture mode
 * adds a "Motion-Triggered (One Picture) " still images capture mode, choosing the best picture from the event
 * rewrites the way still images motion options are mapped to motionEye options