### PR TITLE
Upgrade Docker image to newest Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
+dist: trusty
 sudo: required
+
 language: bash
+
 services:
   - docker
-before_install:
-  - docker info
-  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-install:
-  - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET -f extra/Dockerfile${EXT} extra
-  - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET uname -a
-after_success:
-  - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
-  - docker push $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET
+
 env:
   # global:
   #   DOCKER_REPO
@@ -22,3 +17,13 @@ env:
     - TARGET=armhf EXT=".armv7-armhf"
 matrix:
   fast_finish: true
+
+before_install:
+  - docker info
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+install:
+  - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET -f extra/Dockerfile${EXT} .
+  - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET uname -a
+after_success:
+  - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
+  - docker push $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+language: bash
+services:
+  - docker
+install:
+  - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH extra
+  - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH uname -a
+env:
+  # DOCKER_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,21 @@ services:
   - docker
 before_install:
   - docker info
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 install:
-  - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH extra
-  - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH uname -a
+  - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET -f extra/Dockerfile${EXT} extra
+  - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET uname -a
 after_success:
   - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
-  - docker push $DOCKER_REPO:$TRAVIS_BRANCH
+  - docker push $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET
 env:
-  # DOCKER_REPO
+  # global:
+  #   DOCKER_REPO
+  #   DOCKER_USERNAME
+  #   DOCKER_PASSWORD
+  #   DOCKER_EMAIL
+  matrix:
+    - TARGET=amd64 EXT=""
+    - TARGET=armhf EXT=".armv7-armhf"
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ services:
 install:
   - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH extra
   - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH uname -a
+after_success:
+  - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
+  - docker push $DOCKER_REPO:$TRAVIS_BRANCH
 env:
   # DOCKER_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 language: bash
 services:
   - docker
+before_install:
+  - docker info
 install:
   - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH extra
   - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH uname -a

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -31,8 +31,7 @@ RUN apt-get --quiet update && \
     python-pip \
     python-setuptools \
     python-wheel && \
-    apt-get autoremove --yes && \
-    apt-get --quiet autoremove && \
+    apt-get --quiet autoremove --yes && \
     apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # R/W needed for motioneye to update configurations

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -3,22 +3,21 @@ LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
 
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-    gcc \
     ffmpeg \
-    libcurl4-openssl-dev \
-    libssl-dev \
     lsb-release \
     motion \
-    python-dev \
+    python-jinja2 \
     python-pip \
+    python-pycurl \
     python-setuptools \
+    python-tornado \
     python-wheel \
     v4l-utils && \
     apt-get --quiet autoremove && \
     apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # Pip
-RUN pip install tornado jinja2 pillow pycurl
+RUN pip install pillow
 
 RUN pip install motioneye
 

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -13,10 +13,14 @@ RUN apt-get --quiet update && \
     python-tornado \
     python-wheel \
     v4l-utils && \
+    pip install motioneye && \
+    apt-get purge --yes \
+    python-pip \
+    python-setuptools \
+    python-wheel && \
+    apt-get autoremove --yes && \
     apt-get --quiet autoremove && \
     apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
-
-RUN pip install motioneye
 
 # R/W needed for motioneye to update configurations
 VOLUME /etc/motioneye

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -47,7 +47,7 @@ VOLUME /var/run/motion
 # Video & images
 VOLUME /var/lib/motioneye
 
-ADD motioneye.conf.sample /usr/share/motioneye/extra/
+ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
 
 CMD test -e /etc/motioneye/motioneye.conf || \    
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -3,41 +3,21 @@ LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
 
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-    automake \
-    autoconf \
-    build-essential \
+    gcc \
     ffmpeg \
-    git \
-    libav-tools \
-    libavcodec-dev \
-    libavformat-dev \
-    libavutil-dev \
     libcurl4-openssl-dev \
-    libjpeg-dev \
     libssl-dev \
-    libswscale-dev \
-    pkgconf \
+    motion \
     python-dev \
     python-pip \
     python-setuptools \
     python-wheel \
-    subversion \
     v4l-utils && \
     apt-get --quiet autoremove && \
     apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # Pip
 RUN pip install tornado jinja2 pillow pycurl
-
-RUN cd /tmp && git clone --branch 4.0 https://github.com/Motion-Project/motion.git motion-project
-RUN cd /tmp/motion-project && \
-    autoreconf -fiv && \
-    ./configure --prefix=/usr --without-pgsql --without-sqlite3 --without-mysql --with-ffmpeg=/usr && \
-    make && \
-    touch README \
-    make install && \
-    cp motion /usr/local/bin/motion && cd / && \
-    rm -rf /tmp/motion-project
 
 RUN pip install motioneye
 

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
     curl \
     ffmpeg \
+    libmysqlclient20 \
+    libpq5 \
     lsb-release \
     python-jinja2 \
     python-olefile \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get --quiet update && \
     ffmpeg \
     libcurl4-openssl-dev \
     libssl-dev \
+    lsb-release \
     motion \
     python-dev \
     python-pip \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get --quiet update && \
     lsb-release \
     motion \
     python-jinja2 \
+    python-olefile \
     python-pip \
     python-pycurl \
     python-setuptools \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get --quiet update && \
     curl \
     ffmpeg \
     lsb-release \
-    motion \
     python-jinja2 \
     python-olefile \
     python-pip \
@@ -26,6 +25,9 @@ RUN apt-get --quiet update && \
     python-tornado \
     python-wheel \
     v4l-utils && \
+    curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.0.1/yakkety_motion_4.0.1-1_amd64.deb && \
+    dpkg -i /tmp/motion.deb && \
+    rm /tmp/motion.deb && \
     pip install motioneye && \
     apt-get purge --yes \
     python-pip \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -16,9 +16,6 @@ RUN apt-get --quiet update && \
     apt-get --quiet autoremove && \
     apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
-# Pip
-RUN pip install pillow
-
 RUN pip install motioneye
 
 # R/W needed for motioneye to update configurations

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,6 +1,17 @@
 FROM ubuntu:17.04
 LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
 
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.docker.dockerfile="extra/Dockerfile" \
+    org.label-schema.license="GPLv3" \
+    org.label-schema.name="motioneye" \
+    org.label-schema.url="https://github.com/ccrisan/motioneye/wiki" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
+
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
     ffmpeg \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,7 +1,5 @@
-FROM ubuntu:15.04
+FROM ubuntu:17.04
 LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
-
-ENV DEBIAN_FRONTEND noninteractive
 
 RUN locale-gen en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,6 +1,5 @@
-
 FROM ubuntu:15.04
-MAINTAINER Conor Heine <conor.heine@gmail.com>
+LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -11,29 +10,29 @@ ENV LANG en_US.UTF-8
 ENV LC_TYPE en_US.UTF-8
 ENV TZ America/Los_Angeles
 
-RUN apt-get update && \
-    apt-get --yes install \
-    	automake \
-	curl \
-	autoconf \
-	build-essential \
-	ffmpeg \
-	git \
-	libav-tools \
-	libavcodec-dev \
-	libavformat-dev \
-	libavutil-dev \
-	libcurl4-openssl-dev \
-	libjpeg-dev \
-	libssl-dev \
-	libswscale-dev \
-	pkgconf \
-        python-dev \
-        python-pip \
-	python-setuptools \
-	subversion \
-	v4l-utils && \
-    apt-get clean
+RUN apt-get --quiet update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+    automake \
+    autoconf \
+    build-essential \
+    ffmpeg \
+    git \
+    libav-tools \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libcurl4-openssl-dev \
+    libjpeg-dev \
+    libssl-dev \
+    libswscale-dev \
+    pkgconf \
+    python-dev \
+    python-pip \
+    python-setuptools \
+    subversion \
+    v4l-utils && \
+    apt-get --quiet autoremove && \
+    apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # Pip
 RUN pip install tornado jinja2 pillow pycurl
@@ -59,11 +58,10 @@ VOLUME /var/run/motion
 # Video & images
 VOLUME /var/lib/motioneye
 
-ADD extra /usr/share/motioneye/extra/
+ADD motioneye.conf.sample /usr/share/motioneye/extra/
 
 CMD test -e /etc/motioneye/motioneye.conf || \    
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 
 EXPOSE 8765
-

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:17.04
-LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
+FROM ubuntu:17.10
+LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -14,6 +14,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+    curl \
     ffmpeg \
     lsb-release \
     motion \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,13 +1,6 @@
 FROM ubuntu:17.04
 LABEL maintainer="Conor Heine <conor.heine@gmail.com>"
 
-RUN locale-gen en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_TYPE en_US.UTF-8
-ENV TZ America/Los_Angeles
-
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
     automake \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get --quiet update && \
     python-dev \
     python-pip \
     python-setuptools \
+    python-wheel \
     subversion \
     v4l-utils && \
     apt-get --quiet autoremove && \

--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get --quiet update && \
     libpq5 \
     lsb-release \
     python-jinja2 \
-    python-olefile \
+    python-pil \
     python-pip \
     python-pycurl \
     python-setuptools \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -12,7 +12,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
 
-ADD sources.list /etc/apt/
+ADD extra/sources.list /etc/apt/
 
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -1,45 +1,40 @@
 FROM multiarch/ubuntu-debootstrap:armhf-zesty
 LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.docker.dockerfile="extra/Dockerfile" \
+    org.label-schema.license="GPLv3" \
+    org.label-schema.name="motioneye" \
+    org.label-schema.url="https://github.com/ccrisan/motioneye/wiki" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
+
 ADD sources.list /etc/apt/
 
 RUN apt-get --quiet update && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-    automake \
-	autoconf \
-	build-essential \
-	ffmpeg \
-	git \
-	libav-tools \
-	libavcodec-dev \
-	libavformat-dev \
-	libavutil-dev \
-	libcurl4-openssl-dev \
-	libjpeg-dev \
-	libssl-dev \
-	libswscale-dev \
-	pkgconf \
-    python-dev \
+    curl \
+    ffmpeg \
+    lsb-release \
+    motion \
+    python-jinja2 \
+    python-olefile \
     python-pip \
-	python-setuptools \
-	subversion \
-	v4l-utils && \
-    apt-get clean
-
-# Pip
-RUN pip install tornado jinja2 pillow pycurl
-
-RUN cd /tmp && git clone --branch 4.0 https://github.com/Motion-Project/motion.git motion-project
-RUN cd /tmp/motion-project && \
-    autoreconf -fiv && \
-    ./configure --prefix=/usr --without-pgsql --without-sqlite3 --without-mysql --with-ffmpeg=/usr && \
-    make && \
-    touch README \
-    make install && \
-    cp motion /usr/local/bin/motion && cd / && \
-    rm -rf /tmp/motion-project
-
-RUN pip install motioneye
+    python-pycurl \
+    python-setuptools \
+    python-tornado \
+    python-wheel \
+    v4l-utils && \
+    pip install motioneye && \
+    apt-get purge --yes \
+    python-pip \
+    python-setuptools \
+    python-wheel && \
+    apt-get --quiet autoremove --yes && \
+    apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # R/W needed for motioneye to update configurations
 VOLUME /etc/motioneye
@@ -57,4 +52,3 @@ CMD test -e /etc/motioneye/motioneye.conf || \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 
 EXPOSE 8765
-

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -46,7 +46,7 @@ VOLUME /var/run/motion
 # Video & images
 VOLUME /var/lib/motioneye
 
-ADD motioneye.conf.sample /usr/share/motioneye/extra/
+ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
 
 CMD test -e /etc/motioneye/motioneye.conf || \    
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -27,7 +27,8 @@ RUN apt-get --quiet update && \
     python-setuptools \
     python-tornado \
     python-wheel \
-    v4l-utils && \
+    v4l-utils \
+    zlib1g-dev && \
     pip install motioneye && \
     apt-get purge --yes \
     python-pip \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -1,5 +1,5 @@
 
-FROM armv7/armhf-ubuntu:15.04
+FROM multiarch/ubuntu-debootstrap:armhf-vivid
 MAINTAINER Conor Heine <conor.heine@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -10,6 +10,8 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_TYPE en_US.UTF-8
 ENV TZ America/Los_Angeles
+
+ADD sources.list /etc/apt/
 
 RUN apt-get update && \
     apt-get --yes install \
@@ -58,7 +60,7 @@ VOLUME /var/run/motion
 # Video & images
 VOLUME /var/lib/motioneye
 
-ADD extra /usr/share/motioneye/extra/
+ADD motioneye.conf.sample /usr/share/motioneye/extra/
 
 CMD test -e /etc/motioneye/motioneye.conf || \    
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -21,7 +21,7 @@ RUN apt-get --quiet update && \
     lsb-release \
     motion \
     python-jinja2 \
-    python-olefile \
+    python-pil \
     python-pip \
     python-pycurl \
     python-setuptools \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -1,21 +1,11 @@
-
-FROM multiarch/ubuntu-debootstrap:armhf-vivid
-MAINTAINER Conor Heine <conor.heine@gmail.com>
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN locale-gen en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_TYPE en_US.UTF-8
-ENV TZ America/Los_Angeles
+FROM multiarch/ubuntu-debootstrap:armhf-zesty
+LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
 ADD sources.list /etc/apt/
 
-RUN apt-get update && \
-    apt-get --yes install \
-    	automake \
+RUN apt-get --quiet update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+    automake \
 	autoconf \
 	build-essential \
 	ffmpeg \
@@ -29,8 +19,8 @@ RUN apt-get update && \
 	libssl-dev \
 	libswscale-dev \
 	pkgconf \
-        python-dev \
-        python-pip \
+    python-dev \
+    python-pip \
 	python-setuptools \
 	subversion \
 	v4l-utils && \

--- a/extra/Dockerfile.local
+++ b/extra/Dockerfile.local
@@ -1,62 +1,46 @@
+FROM ubuntu:17.10
+LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
-FROM ubuntu:15.04
-MAINTAINER Conor Heine <conor.heine@gmail.com>
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.docker.dockerfile="extra/Dockerfile" \
+    org.label-schema.license="GPLv3" \
+    org.label-schema.name="motioneye" \
+    org.label-schema.url="https://github.com/ccrisan/motioneye/wiki" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN locale-gen en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_TYPE en_US.UTF-8
-ENV TZ America/Los_Angeles
-
-RUN apt-get update && \
-    apt-get --yes install \
-    	automake \
-	autoconf \
-	build-essential \
-	ffmpeg \
-	git \
-	libav-tools \
-	libavcodec-dev \
-	libavformat-dev \
-	libavutil-dev \
-	libcurl4-openssl-dev \
-	libjpeg-dev \
-	libssl-dev \
-	libswscale-dev \
-	pkgconf \
-        python-dev \
-        python-pip \
-	python-setuptools \
-	subversion \
-	v4l-utils && \
-    apt-get clean
-
-# Pip
-RUN pip install tornado jinja2 pillow pycurl
-
-# Install motion
-RUN cd /tmp && git clone --branch 4.0 https://github.com/Motion-Project/motion.git motion-project
-RUN cd /tmp/motion-project && \
-    autoreconf -fiv && \
-    ./configure --prefix=/usr --without-pgsql --without-sqlite3 --without-mysql --with-ffmpeg=/usr && \
-    make && \
-    touch README \
-    make install && \
-    cp motion /usr/local/bin/motion && cd / && \
-    rm -rf /tmp/motion-project
-
-# Install motioneye from local source
 COPY . /tmp/motioneye
-RUN cd /tmp/motioneye && \
-    python setup.py install && \
-    mkdir /etc/motioneye && \
-    mkdir -p /var/lib/motioneye && \
-    mkdir -p /usr/share/motioneye/extra && \
-    cp /tmp/motioneye/extra/motioneye.conf.sample /usr/share/motioneye/extra/motioneye.conf.sample && \
-    rm -rf /tmp/motioneye
+
+RUN apt-get --quiet update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+    curl \
+    ffmpeg \
+    libmysqlclient20 \
+    libpq5 \
+    lsb-release \
+    python-jinja2 \
+    python-pil \
+    python-pip \
+    python-pycurl \
+    python-setuptools \
+    python-tornado \
+    python-wheel \
+    v4l-utils && \
+    curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.0.1/yakkety_motion_4.0.1-1_amd64.deb && \
+    dpkg -i /tmp/motion.deb && \
+    rm /tmp/motion.deb && \
+    cd /tmp/motioneye && \
+    pip install /tmp/motioneye && \
+    rm -rf /tmp/motioneye && \ 
+    apt-get purge --yes \
+    python-pip \
+    python-setuptools \
+    python-wheel && \
+    apt-get --quiet autoremove --yes && \
+    apt-get --quiet --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # R/W needed for motioneye to update configurations
 VOLUME /etc/motioneye
@@ -67,9 +51,10 @@ VOLUME /var/run/motion
 # Video & images
 VOLUME /var/lib/motioneye
 
+ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
+
 CMD test -e /etc/motioneye/motioneye.conf || \    
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 
 EXPOSE 8765
-

--- a/extra/motioneye-docker.conf
+++ b/extra/motioneye-docker.conf
@@ -1,0 +1,26 @@
+description "motionEye Server in Docker container"
+author "Marcus Klein <himself@kleini.org>"
+
+start on filesystem and started docker
+stop on runlevel [!2345]
+respawn
+script
+  /usr/bin/docker stop motioneye || true
+  /usr/bin/docker rm motioneye || true
+  docker run --name=motioneye \
+    -p 8081:8081 \
+    -p 8765:8765 \
+    -h server \
+    -e TZ="Europe/Berlin" \
+    -v /docker/motioneye:/etc/motioneye \
+    -v /var/lib/motioneye:/var/lib/motioneye \
+    --restart=always \
+    kleini/motioneye:docker
+end script
+pre-stop script
+  if docker ps | grep -q motioneye
+  then
+    docker stop motioneye
+    docker rm motioneye
+  fi
+end script

--- a/extra/sources.list
+++ b/extra/sources.list
@@ -1,35 +1,3 @@
-# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
-# newer versions of the distribution.
-
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted
-
-## Major bug fix updates produced after the final release of the
-## distribution.
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted
-
-## Uncomment the following two lines to add software from the 'universe'
-## repository.
-## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
-## team. Also, please note that software in universe WILL NOT receive any
-## review or updates from the Ubuntu security team.
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid universe
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid universe
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid-updates universe
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-updates universe
-
-## N.B. software from this repository may not have been tested as
-## extensively as that contained in the main release, although it includes
-## newer versions of some applications which may provide useful features.
-## Also, please note that software in backports WILL NOT receive any review
-## or updates from the Ubuntu security team.
-# deb http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
-# deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
-
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted
-deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security universe
-deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security universe
-# deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security multiverse
-# deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty main restricted universe
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-updates main restricted universe
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-security main restricted universe

--- a/extra/sources.list
+++ b/extra/sources.list
@@ -1,0 +1,35 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted
+
+## Uncomment the following two lines to add software from the 'universe'
+## repository.
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid universe
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-updates universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-updates universe
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+# deb http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security universe
+# deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security multiverse

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,2 +1,2 @@
 
-VERSION = "0.37"
+VERSION = "0.37.1"


### PR DESCRIPTION
Thanks for the Docker image of motioneye! I am using it the observation system at home. motioneye makes the use of the motion daemon a pleasure.

I am always curious to try newest versions of software. This time I tried to upgrade the Docker image to the newest Ubuntu base image. Furthermore I was able to simplify the creation of the Docker image a lot because Ubuntu Zesty already packages a lot of needed software.

The simplified creation also results in a much smaller size of the image. The previous image is 674M and my upgraded one is just 422M.
The image is automatically build on Docker Hub: https://hub.docker.com/r/kleini/motioneye/

My host system is running an outdated Ubuntu Trusty. Therefore I would like to contribute an upstart script for the motioneye Docker container, too.

