### PR TITLE
Update Dockerfile

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -14,6 +14,7 @@ ENV TZ America/Los_Angeles
 RUN apt-get update && \
     apt-get --yes install \
     	automake \
+	curl \
 	autoconf \
 	build-essential \
 	ffmpeg \


### PR DESCRIPTION
added installation of curl, as my motion log file threw errors about not finding curl when taking a manual snapshot.