### PR TITLE
Fixed not working docker login for pushing images to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,15 @@
 dist: trusty
-sudo: required
-
-language: bash
-
-services:
-  - docker
+sudo: true
 
 env:
-  # global:
-  #   DOCKER_REPO
-  #   DOCKER_USERNAME
-  #   DOCKER_PASSWORD
-  #   DOCKER_EMAIL
-  matrix:
-    - TARGET=amd64 EXT=""
-    - TARGET=armhf EXT=".armv7-armhf"
-matrix:
-  fast_finish: true
+  - TARGET=amd64 EXT=""
+  - TARGET=armhf EXT=".armv7-armhf"
 
-before_install:
+script:
   - docker info
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-install:
   - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") -t $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET -f extra/Dockerfile${EXT} .
   - docker run --rm $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET uname -a
-after_success:
-  - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
+  - echo $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker push $DOCKER_REPO:$TRAVIS_BRANCH-$TARGET
+


### PR DESCRIPTION
Pushing to Docker Hub in after_success stage will not fail the build if
the login fails. See https://github.com/travis-ci/travis-ci/issues/758.
Use Travis CI build stages.