### PR TITLE
Add option to encrypt media files before uploading

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get --quiet update && \
     curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.1/artful_motion_4.1-1_amd64.deb && \
     dpkg -i /tmp/motion.deb && \
     rm /tmp/motion.deb && \
+    pip install pynacl && \
     pip install /tmp/motioneye && \
     rm -rf /tmp/motioneye && \
     apt-get purge --yes \
@@ -53,7 +54,7 @@ VOLUME /var/lib/motioneye
 
 ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
 
-CMD test -e /etc/motioneye/motioneye.conf || \    
+CMD test -e /etc/motioneye/motioneye.conf || \
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -18,12 +18,15 @@ ENV LD_LIBRARY_PATH /opt/vc/lib
 RUN apt-get --quiet update && \
     apt-get --quiet upgrade --yes && \
     DEBIAN_FRONTEND="noninteractive" apt-get --quiet --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+    build-essential \
     curl \
     ffmpeg \
     git \
+    libffi-dev \
     libmariadbclient18 \
     libpq5 \
     lsb-release \
+    python-dev \
     python-jinja2 \
     python-pil \
     python-pip \
@@ -39,6 +42,7 @@ RUN apt-get --quiet update && \
     curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.1/pi_stretch_motion_4.1-1_armhf.deb && \
     dpkg -i /tmp/motion.deb && \
     rm /tmp/motion.deb && \
+    pip install pynacl && \
     pip install /tmp/motioneye && \
     rm -rf /tmp/motioneye && \
     apt-get purge --yes \
@@ -60,7 +64,7 @@ VOLUME /var/lib/motioneye
 
 ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
 
-CMD test -e /etc/motioneye/motioneye.conf || \    
+CMD test -e /etc/motioneye/motioneye.conf || \
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -5,14 +5,14 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections
 import datetime
@@ -752,6 +752,9 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         '@upload_method': ui['upload_method'],
         '@upload_location': ui['upload_location'],
         '@upload_subfolders': ui['upload_subfolders'],
+        '@cloud_encryption_enabled': ui['cloud_encryption_enabled'],
+        '@cloud_encryption_upload_fails': ui['cloud_encryption_upload_fails'],
+        '@cloud_encryption_remove_unencrypted': ui['cloud_encryption_remove_unencrypted'],
         '@upload_username': ui['upload_username'],
         '@upload_password': ui['upload_password'],
 
@@ -817,8 +820,8 @@ def motion_camera_ui_to_dict(ui, old_config=None):
         proto = 'v4l2'
 
     elif utils.is_mmal_camera(old_config):
-        proto = 'mmal'     
-   
+        proto = 'mmal'
+
     else:
         proto = 'netcam'
 
@@ -1062,7 +1065,7 @@ def motion_camera_ui_to_dict(ui, old_config=None):
 
     if ui['command_end_notifications_enabled']:
         on_event_end += utils.split_semicolon(ui['command_end_notifications_exec'])
-    
+
     data['on_event_end'] = '; '.join(on_event_end)
 
     # movie end
@@ -1149,6 +1152,9 @@ def motion_camera_dict_to_ui(data):
         'upload_method': data['@upload_method'],
         'upload_location': data['@upload_location'],
         'upload_subfolders': data['@upload_subfolders'],
+        'cloud_encryption_enabled': data['@cloud_encryption_enabled'],
+        'cloud_encryption_upload_fails': data['@cloud_encryption_upload_fails'],
+        'cloud_encryption_remove_unencrypted': data['@cloud_encryption_remove_unencrypted'],
         'upload_username': data['@upload_username'],
         'upload_password': data['@upload_password'],
         'upload_authorization_key': '',  # needed, otherwise the field is hidden
@@ -1210,7 +1216,7 @@ def motion_camera_dict_to_ui(data):
         'web_hook_notifications_enabled': False,
         'command_notifications_enabled': False,
         'command_end_notifications_enabled': False,
-        
+
         # working schedule
         'working_schedule': False,
         'working_schedule_type': 'during',
@@ -1244,7 +1250,7 @@ def motion_camera_dict_to_ui(data):
     elif utils.is_mmal_camera(data):
         ui['device_url'] = data['mmalcam_name']
         ui['proto'] = 'mmal'
-        
+
         resolutions = utils.COMMON_RESOLUTIONS
         resolutions = [r for r in resolutions if motionctl.resolution_is_valid(*r)]
         ui['available_resolutions'] = [(str(w) + 'x' + str(h)) for (w, h) in resolutions]
@@ -1263,7 +1269,7 @@ def motion_camera_dict_to_ui(data):
 
         # the brightness & co. keys in the ui dictionary
         # indicate the presence of these controls
-        # we must call v4l2ctl functions to determine the available controls    
+        # we must call v4l2ctl functions to determine the available controls
         brightness = v4l2ctl.get_brightness(data['videodevice'])
         if brightness is not None:  # has brightness control
             if data.get('brightness', 0) != 0:
@@ -1967,6 +1973,9 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_method', 'POST')
     data.setdefault('@upload_location', '')
     data.setdefault('@upload_subfolders', True)
+    data.setdefault('@cloud_encryption_enabled', False)
+    data.setdefault('@cloud_encryption_upload_fails', False)
+    data.setdefault('@cloud_encryption_remove_unencrypted', False)
     data.setdefault('@upload_username', '')
     data.setdefault('@upload_password', '')
 

--- a/motioneye/encrypt.py
+++ b/motioneye/encrypt.py
@@ -1,0 +1,70 @@
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from nacl import encoding, public
+
+import config
+import logging
+import os
+import re
+import settings
+
+public_key_location = os.path.join(settings.CONF_PATH, 'public.key')
+private_key_location = os.path.join(settings.CONF_PATH, 'private.key')
+used_encoder = encoding.RawEncoder
+
+def read_public_key(public_key_location):
+    with open(public_key_location, 'rb') as key_file:
+            public_key = key_file.read()
+    return public.PublicKey(public_key, encoder=used_encoder)
+
+def read_media_file(infile):
+    with open(infile, 'rb') as in_file:
+        data = in_file.read()
+        outfile = re.sub(r'(\.[a-zA-Z0-9]*$)', r'\1.crypt', infile)
+    return data, outfile
+
+def write_file(outfile, data):
+    with open(outfile, 'wb') as out_file:
+        out_file.write(data)
+    return outfile
+
+def sealed_box(public_key, data):
+    box = public.SealedBox(public_key)
+    return box.encrypt(data)
+
+def remove_source_file(input_file, camera_id):
+    camera_config = config.get_camera(camera_id)
+    if camera_config['@cloud_encryption_remove_unencrypted']:
+        logging.debug('Deleting unencrypted source file "%s"' % input_file)
+        os.remove(input_file)
+
+def encrypt(input_file, camera_id):
+    try:
+        data, outfile = read_media_file(input_file)
+        public_key = read_public_key(public_key_location)
+        encrypted = sealed_box(public_key, data)
+        outfile = write_file(outfile, encrypted)
+        logging.debug('Successfully encrypted "%s" to "%s"' % (input_file, outfile))
+        remove_source_file(input_file, camera_id)
+        return outfile
+    except:
+        camera_config = config.get_camera(camera_id)
+        if camera_config['@cloud_encryption_upload_fails']:
+            logging.error('Encryption of file "%s" failed. Uploading unencrypted file' % input_file)
+            return input_file
+        else:
+            logging.error('Encryption of file "%s" failed. Not uploading unencrypted file' % input_file)
+            return None

--- a/motioneye/encrypt.py
+++ b/motioneye/encrypt.py
@@ -48,7 +48,7 @@ def sealed_box(public_key, data):
 def remove_source_file(input_file, camera_id):
     camera_config = config.get_camera(camera_id)
     if camera_config['@cloud_encryption_remove_unencrypted']:
-        logging.debug('Deleting unencrypted source file "%s"' % input_file)
+        logging.debug('Deleting unencrypted source file {0}'.format(input_file))
         os.remove(input_file)
 
 def encrypt(input_file, camera_id):
@@ -57,14 +57,14 @@ def encrypt(input_file, camera_id):
         public_key = read_public_key(public_key_location)
         encrypted = sealed_box(public_key, data)
         outfile = write_file(outfile, encrypted)
-        logging.debug('Successfully encrypted "%s" to "%s"' % (input_file, outfile))
+        logging.debug('Successfully encrypted {0} to {1}'.format(input_file, outfile))
         remove_source_file(input_file, camera_id)
         return outfile
     except:
         camera_config = config.get_camera(camera_id)
         if camera_config['@cloud_encryption_upload_fails']:
-            logging.error('Encryption of file "%s" failed. Uploading unencrypted file' % input_file)
+            logging.error('Encryption of file {0} failed. Uploading unencrypted file'.format(input_file))
             return input_file
         else:
-            logging.error('Encryption of file "%s" failed. Not uploading unencrypted file' % input_file)
+            logging.error('Encryption of file {0} failed. Not uploading unencrypted file'.format(input_file))
             return None

--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -28,6 +28,7 @@ from tornado.ioloop import IOLoop
 from tornado.web import RequestHandler, StaticFileHandler, HTTPError, asynchronous
 
 import config
+import encrypt
 import mediafiles
 import mjpgclient
 import mmalctl
@@ -1838,7 +1839,10 @@ class RelayEventHandler(BaseHandler):
     
     def upload_media_file(self, filename, camera_id, camera_config):
         service_name = camera_config['@upload_service']
-        
+
+        if camera_config['@cloud_encryption_enabled']:
+            filename = encrypt.encrypt(filename, camera_id)
+
         tasks.add(5, uploadservices.upload_media_file, tag='upload_media_file(%s)' % filename,
                 camera_id=camera_id, service_name=service_name,
                 target_dir=camera_config['@upload_subfolders'] and camera_config['target_dir'],

--- a/motioneye/meyeDecrypt.py
+++ b/motioneye/meyeDecrypt.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+from nacl import encoding, public, pwhash, secret, utils
+
+import argparse
+import os
+import re
+import sys
+import getpass
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-k", metavar="/path/to/private.key", help="Private key to use")
+parser.add_argument("--directory", metavar="/path/to/mediafiles.mp4.crypt", help="Decrypt all files ending with .crypt in this directory")
+parser.add_argument("--file", metavar="/path/to/mediafile.mp4.crypt", help="Decrypt only the specified file")
+
+
+kdf = pwhash.argon2i.kdf
+ops = pwhash.argon2i.OPSLIMIT_SENSITIVE
+
+def decrypt_key(private_key):
+    password = getpass.getpass()
+
+    with open (private_key, 'r') as in_file:
+        salt = in_file.read(16)
+        in_file.seek(16)
+        encrypted = in_file.read(72)
+        in_file.seek(88)
+        mem = int(in_file.read())
+
+    key = kdf(secret.SecretBox.KEY_SIZE, password, salt,
+               opslimit=ops, memlimit=mem)
+    box = secret.SecretBox(key)
+
+    loaded_private_key = box.decrypt(encrypted)
+
+    loaded_private_key = public.PrivateKey(loaded_private_key, encoder=encoding.RawEncoder)
+
+    return loaded_private_key
+
+
+def decrypt_files_in_dir(loaded_private_key, directory):
+    for file in os.listdir(directory):
+        if file.endswith(".crypt"):
+            try:
+                file = os.path.join(os.path.abspath(directory), file)
+
+                outfile = re.sub('\.crypt$', '', file)
+
+                with open(file, 'rb') as in_file:
+                    data = in_file.read()
+
+                    box = public.SealedBox(loaded_private_key)
+
+                    decrypted = box.decrypt(data)
+
+                    with open(outfile, 'wb') as out_file:
+                        out_file.write(decrypted)
+
+                        print ("Decrypted %s to %s" % (file, outfile))
+            except:
+                print ("Failed to decrypt %s") % file
+
+def decrypt_file(loaded_private_key, file):
+    if file.endswith(".crypt"):
+
+        file = os.path.abspath(file)
+
+        outfile = re.sub('\.crypt$', '', file)
+
+        with open(file, 'rb') as in_file:
+            data = in_file.read()
+
+        box = public.SealedBox(loaded_private_key)
+
+        decrypted = box.decrypt(data)
+
+        with open(outfile, 'wb') as out_file:
+            out_file.write(decrypted)
+
+        print ("Decrypted %s to %s" % (file, outfile))
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    loaded_private_key = decrypt_key(args.k)
+
+    if args.directory:
+        decrypt_files_in_dir(loaded_private_key, args.directory)
+
+    if args.file:
+        decrypt_file(loaded_private_key, args.file)

--- a/motioneye/meyeDecrypt.py
+++ b/motioneye/meyeDecrypt.py
@@ -56,9 +56,9 @@ def decrypt_files_in_dir(loaded_private_key, directory):
                     with open(outfile, 'wb') as out_file:
                         out_file.write(decrypted)
 
-                        print ("Decrypted %s to %s" % (file, outfile))
+                        print ("Decrypted {0} to {1}".format(file, outfile))
             except:
-                print ("Failed to decrypt %s") % file
+                print ("Failed to decrypt {0}".format(file))
 
 def decrypt_file(loaded_private_key, file):
     if file.endswith(".crypt"):
@@ -77,7 +77,7 @@ def decrypt_file(loaded_private_key, file):
         with open(outfile, 'wb') as out_file:
             out_file.write(decrypted)
 
-        print ("Decrypted %s to %s" % (file, outfile))
+        print ("Decrypted {0} to {1}".format(file, outfile))
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/motioneye/meyeGenerateKeys.py
+++ b/motioneye/meyeGenerateKeys.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from nacl import encoding, public, pwhash, secret, utils
+import argparse
+import datetime
+import getpass
+import os
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--memlimit", type=int, metavar="int", help="Maximum amount of memory in bytes to use for key decryption")
+parser.add_argument("--directory", metavar="/etc/motioneye", help="Directory to write keys to; Public key must be present in the motioneye config directory for encryption to work")
+
+used_encoder = encoding.RawEncoder
+
+kdf = pwhash.argon2i.kdf
+salt = utils.random(pwhash.argon2i.SALTBYTES)
+ops = pwhash.argon2i.OPSLIMIT_SENSITIVE
+
+def encrypt_key(mem, key):
+    password = getpass.getpass()
+
+    derivated_password = kdf(secret.SecretBox.KEY_SIZE, password, salt, opslimit=ops, memlimit=mem)
+
+    secret_box = secret.SecretBox(derivated_password)
+    encrypted_private_key = secret_box.encrypt(key)
+    return encrypted_private_key
+
+def write_private_key(outfile, salt, encrypted_key, mem):
+    with open(outfile, 'wb') as out_file:
+        out_file.write(salt)
+        out_file.write(encrypted_key)
+        out_file.write(str(mem))
+
+def write_public_key(outfile, public_key):
+    with open(outfile, 'wb') as out_file:
+        out_file.write(public_key)
+
+def backup_key_files(private_key_location, public_key_location):
+    now = datetime.datetime.now()
+    now = now.strftime("_%Y-%m-%d_%H_%M_%S")
+    backup_private_key_location = os.path.join(private_key_location + now)
+    backup_public_key_location = os.path.join(public_key_location + now)
+
+    if os.path.isfile(private_key_location):
+        os.rename(private_key_location, backup_private_key_location)
+        print ("Existing private key %s was backuped to %s" % (private_key_location, backup_private_key_location))
+
+    if os.path.isfile(public_key_location):
+        os.rename(public_key_location, backup_public_key_location)
+        print ("Existing public key %s was backuped to %s" % (public_key_location, backup_public_key_location))
+
+
+def generate_key_pair(mem, private_key_location, public_key_location):
+    backup_key_files(private_key_location, public_key_location)
+
+    private_key = public.PrivateKey.generate()
+
+    encoded_private_key = private_key.encode(encoder=used_encoder)
+    encoded_public_key = private_key.public_key.encode(encoder=used_encoder)
+
+    encrypted_private_key = encrypt_key(mem, encoded_private_key)
+
+    write_private_key(private_key_location, salt, encrypted_private_key, mem)
+    write_public_key(public_key_location, encoded_public_key)
+
+    print('IMPORTANT: Backup the newly generated private key at %s immediately. If you lose it, you will not be able to decrypt your files.' % private_key_location)
+
+def main():
+    args = parser.parse_args()
+    if args.memlimit:
+        if args.memlimit >= 8192:
+            mem = args.memlimit
+            print ("Using custom memory limit of %i") % mem
+        else:
+            sys.exit("ERROR: memlimit must be at least 8192 bytes")
+    else:
+        mem = pwhash.argon2i.MEMLIMIT_SENSITIVE
+        print ("Using default memory limit of %i") % mem
+
+    if args.directory:
+        if os.path.exists(args.directory):
+            directory = args.directory
+            print ("Using specified directory %s as output directory" % directory)
+        else:
+            sys.exit("ERROR: Specified output directory %s does not exist" % args.directory)
+    else:
+        directory = os.getcwd()
+        print ("No output directory specified. Using current directory %s as output directory." % directory)
+
+    public_key_location = os.path.join(directory, 'public.key')
+    private_key_location = os.path.join(directory, 'private.key')
+
+    generate_key_pair(mem, private_key_location, public_key_location)
+
+if __name__ == "__main__":
+    main()

--- a/motioneye/meyeGenerateKeys.py
+++ b/motioneye/meyeGenerateKeys.py
@@ -58,11 +58,11 @@ def backup_key_files(private_key_location, public_key_location):
 
     if os.path.isfile(private_key_location):
         os.rename(private_key_location, backup_private_key_location)
-        print ("Existing private key %s was backuped to %s" % (private_key_location, backup_private_key_location))
+        print ("Existing private key {0} was backuped to {1}".format(private_key_location, backup_private_key_location))
 
     if os.path.isfile(public_key_location):
         os.rename(public_key_location, backup_public_key_location)
-        print ("Existing public key %s was backuped to %s" % (public_key_location, backup_public_key_location))
+        print ("Existing public key {0} was backuped to {1}".format(public_key_location, backup_public_key_location))
 
 
 def generate_key_pair(mem, private_key_location, public_key_location):
@@ -78,29 +78,29 @@ def generate_key_pair(mem, private_key_location, public_key_location):
     write_private_key(private_key_location, salt, encrypted_private_key, mem)
     write_public_key(public_key_location, encoded_public_key)
 
-    print('IMPORTANT: Backup the newly generated private key at %s immediately. If you lose it, you will not be able to decrypt your files.' % private_key_location)
+    print('IMPORTANT: Backup the newly generated private key at {0} immediately. If you lose it, you will not be able to decrypt your files.'.format(private_key_location))
 
 def main():
     args = parser.parse_args()
     if args.memlimit:
         if args.memlimit >= 8192:
             mem = args.memlimit
-            print ("Using custom memory limit of %i") % mem
+            print ("Using custom memory limit of {0}".format(mem))
         else:
             sys.exit("ERROR: memlimit must be at least 8192 bytes")
     else:
         mem = pwhash.argon2i.MEMLIMIT_SENSITIVE
-        print ("Using default memory limit of %i") % mem
+        print ("Using default memory limit of {0}".format(mem))
 
     if args.directory:
         if os.path.exists(args.directory):
             directory = args.directory
-            print ("Using specified directory %s as output directory" % directory)
+            print ("Using specified directory {0} as output directory".format(directory))
         else:
-            sys.exit("ERROR: Specified output directory %s does not exist" % args.directory)
+            sys.exit("ERROR: Specified output directory {0} does not exist".format(args.directory))
     else:
         directory = os.getcwd()
-        print ("No output directory specified. Using current directory %s as output directory." % directory)
+        print ("No output directory specified. Using current directory {0} as output directory.".format(directory))
 
     public_key_location = os.path.join(directory, 'public.key')
     private_key_location = os.path.join(directory, 'private.key')

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1848,6 +1848,9 @@ function cameraUi2Dict() {
         'upload_method': $('#uploadMethodSelect').val(),
         'upload_location': $('#uploadLocationEntry').val(),
         'upload_subfolders': $('#uploadSubfoldersSwitch')[0].checked,
+        'cloud_encryption_enabled': $('#cloudEncryptionSwitch')[0].checked,
+        'cloud_encryption_upload_fails': $('#cloudEncryptionUploadFailsSwitch')[0].checked,
+        'cloud_encryption_remove_unencrypted': $('#cloudEncryptionRemoveUnencryptedSwitch')[0].checked,
         'upload_username': $('#uploadUsernameEntry').val(),
         'upload_password': $('#uploadPasswordEntry').val(),
         'upload_authorization_key': $('#uploadAuthorizationKeyEntry').val(),
@@ -2166,6 +2169,9 @@ function dict2CameraUi(dict) {
     $('#uploadMethodSelect').val(dict['upload_method']); markHideIfNull('upload_method', 'uploadMethodSelect');
     $('#uploadLocationEntry').val(dict['upload_location']); markHideIfNull('upload_location', 'uploadLocationEntry');
     $('#uploadSubfoldersSwitch')[0].checked = dict['upload_subfolders']; markHideIfNull('upload_subfolders', 'uploadSubfoldersSwitch');
+    $('#cloudEncryptionSwitch')[0].checked = dict['cloud_encryption_enabled']; markHideIfNull('cloud_encryption_enabled', 'cloudEncryptionSwitch');
+    $('#cloudEncryptionUploadFailsSwitch')[0].checked = dict['cloud_encryption_upload_fails']; markHideIfNull('cloud_encryption_upload_fails', 'cloudEncryptionUploadFailsSwitch');
+    $('#cloudEncryptionRemoveUnencryptedSwitch')[0].checked = dict['cloud_encryption_remove_unencrypted']; markHideIfNull('cloud_encryption_remove_unencrypted', 'cloudEncryptionRemoveUnencryptedSwitch');
     $('#uploadUsernameEntry').val(dict['upload_username']); markHideIfNull('upload_username', 'uploadUsernameEntry');
     $('#uploadPasswordEntry').val(dict['upload_password']); markHideIfNull('upload_password', 'uploadPasswordEntry');
     $('#uploadAuthorizationKeyEntry').val(dict['upload_authorization_key']); markHideIfNull('upload_authorization_key', 'uploadAuthorizationKeyEntry');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -136,7 +136,7 @@
                         <td><span class="help-mark" title="dims the actual resolution of all cameras to save network bandwidth and traffic (doesn't work on simple MJPEG cameras)">?</span></td>
                     </tr>
                 </table>
-                
+
                 <tr class="settings-item advanced-setting">
                     <td colspan="100"><div class="settings-item-separator" style="margin: 0px 0px 1.5em 0px;"></div></td>
                 </tr>
@@ -237,13 +237,13 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                {% endif %}                    
+                {% endif %}
                 {% endfor %}
 
                 <tr class="settings-item advanced-setting">
                     <td colspan="100"><div class="settings-item-separator" style="margin: 0px 0px 1.5em 0px;"></div></td>
                 </tr>
-                
+
                 <!-- Video Device -->
                 <div class="settings-section-title" id="deviceSectionDiv">
                     <input type="checkbox" class="styled section device camera-config" id="videoDeviceEnabledSwitch">
@@ -345,7 +345,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                
+
                 <!-- File Storage -->
                 <div class="settings-section-title advanced-setting" id="storageSectionDiv">
                     <span class="help-mark" title="choose where and how your media files are saved">?</span>
@@ -463,6 +463,21 @@
                         <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="uploadSubfoldersSwitch"></td>
                         <td><span class="help-mark" title="enable this to upload the media files together with their subfolders, instead of placing them directly into the root location">?</span></td>
                     </tr>
+                    <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Encrypt files before cloud upload</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="cloudEncryptionSwitch"></td>
+                        <td><span class="help-mark" title="Enables encryption for media files before they're uploaded to the cloud. Don't forget to generate keys with generateKeys.py and place them in motioneye config directory.">?</span></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Upload unencrypted files, if encryption fails</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="cloudEncryptionUploadFailsSwitch"></td>
+                        <td><span class="help-mark" title="Enable upload of unencrypted media files to the cloud, if encryption fails?">?</span></td>
+                    </tr>
+                    <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <td class="settings-item-label"><span class="settings-item-label">Remove unencrypted files after encryption</span></td>
+                        <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="cloudEncryptionRemoveUnencryptedSwitch"></td>
+                        <td><span class="help-mark" title="Remove unencrypted media files from local storage after they've been encrypted?">?</span></td>
+                    </tr>
                     <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService=(ftp|sftp|http|https)">
                         <td class="settings-item-label"><span class="settings-item-label">Username</span></td>
                         <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadUsernameEntry"></td>
@@ -534,7 +549,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                
+
                 <!-- Text Overlay -->
                 <div class="settings-section-title advanced-setting" id="textOverlaySectionDiv">
                     <input type="checkbox" class="styled section text-overlay camera-config" id="textOverlayEnabledSwitch">
@@ -667,7 +682,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                
+
                 <!-- Still Images -->
                 <div class="settings-section-title" id="stillImagesSectionDiv">
                     <input type="checkbox" class="styled section still-images camera-config" id="stillImagesEnabledSwitch">
@@ -736,7 +751,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                
+
                 <!-- Movies -->
                 <div class="settings-section-title" id="moviesSectionDiv">
                     <input type="checkbox" class="styled section movies camera-config" id="moviesEnabledSwitch">
@@ -928,7 +943,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                
+
                 <!-- Motion Notifications -->
                 <div class="settings-section-title advanced-setting" id="notificationsSectionDiv">
                     <span class="help-mark" title="enable this if you want to be notified when motion is detected">?</span>
@@ -1142,7 +1157,7 @@
                         {{config_item(config)}}
                     {% endfor %}
                 </table>
-                {% endif %}                    
+                {% endif %}
                 {% endfor %}
 
                 <div class="settings-progress"></div>
@@ -1152,13 +1167,13 @@
         <div class="page-container"></div>
         <div class="footer">
             <div class="copyright-note">copyright &copy; Calin Crisan</div>
-        </div> 
+        </div>
     </div>
     {% else %}
         <div class="camera-frame" id="camera{{camera_id}}"
                 streaming_framerate="{{camera_config['stream_maxrate']}}" streaming_server_resize="{{camera_config['@webcam_server_resize']|string|lower}}"
                 proto="{{camera_config['@proto']}}" url="{{camera_config['@url']}}">
-            
+
             <div class="camera-container">
                 <div class="camera-placeholder"><img class="no-camera" src="{{static_path}}img/no-camera.svg"></div><img
                     class="camera"><div class="camera-progress"><img class="camera-progress"></div>

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
     entry_points={
         'console_scripts': [
             'meyectl=motioneye.meyectl:main',
+            'meyeGenerateKeys=motioneye.meyeGenerateKeys:main',
         ],
     },
     


### PR DESCRIPTION
I added an encryption module, which allows users to automatically encrypt their videos and photos before uploading them to an external file storage such as Google Drive.

It requires PyNaCl version 1.2.0 or greater and works as follows:

Execute `meyeGenerateKeys --directory /etc/motioneye` to generate a key pair. The private key is encrypted with a password and used to decrypt the files, the public key is used to encrypt the files.
meyeGenerateKeys uses over 500mb of RAM to encrypt the key by default. With the option `--memlimit` a smaller value can be specified for computers such as the Raspberry Pi 1, which has only 512 mb of RAM in total.

Once the keys have been created and the public key has been placed in the motionEye config directory, three options below file storage can be used. They're all set to False by default.

The private key can be removed from the device completely and stored in a safe location because it is not needed for encryption. This way a device can be stolen and nobody will be able to decrypt the media files on it, if the user has set both "Encrypt files before cloud upload" and "Remove unencrypted files after encryption" to True.

To decrypt files `meyeDecrypt` can be used. It works as follows:
`meyeDecrypt -k /path/to/private.key --file /path/to/file.mp4.crypt`
or to decrypt all files ending with .crypt in a directory:
`meyeDecrypt -k /path/to/private.key --directory /path/to/dir`

![screenshot_20180311_155402](https://user-images.githubusercontent.com/31535155/37254873-83a2df42-2544-11e8-8856-a58b95aa2c45.png)
 
If there are any questions feel free to ask!