### PR TITLE
Fix "could not delete temp file" error for local camera in MoviePlaybackHandler

### DIFF
--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -1669,7 +1669,7 @@ class MoviePlaybackHandler(StaticFileHandler, BaseHandler):
                 if os.path.isfile(f) and os.stat(f).st_atime <= stale_time:
                     os.remove(f)
         except:
-            logging.exception('could not delete temp file')
+            logging.error('could not delete temp file', exc_info=True)
             pass
 
     def get_absolute_path(self, root, path):


### PR DESCRIPTION
`MoviePlaybackHandler` doesn't handle local camera correctly. When opening movie playback dialog - you will see `could not delete temp file` message in logs.

Reason:
1. Temp directory is created only when fetch executed for remote camera.
2. `on_finish` is called for any camera type and tries to list temp directory.
3. Temp directory is not created for local camera, trying to list it triggers exception.

Fix:
1. I have moved directory creation inside the body of movie playback handler. I don't see problems to create it there on init and not on first request to remote camera. Why not? It's temp directory.
2. Replaced `error()`  call with `exception()` one, because `could not delete temp file` says nothing. Which file? What action?