### PR TITLE
Fix for issue #914. dropbox uploader file truncation

### DIFF
--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -54,7 +54,8 @@ class UploadService(object):
     def upload_file(self, target_dir, filename):
         if target_dir:
             target_dir = os.path.realpath(target_dir)
-            rel_filename = filename[len(target_dir):]
+            rel_filename = os.path.realpath(filename)
+            rel_filename = rel_filename[len(target_dir):]
 
             while rel_filename.startswith('/'):
                 rel_filename = rel_filename[1:]


### PR DESCRIPTION
Fix incorrect path manipulation when using symlink for dropbox and other upload services. Use os.path.realpath() on rel_filename before truncating for target filename.