### PR TITLE
Url prefix: add support for non-root serving of motion-eye

### DIFF
--- a/extra/motioneye.conf.sample
+++ b/extra/motioneye.conf.sample
@@ -21,6 +21,10 @@ listen 0.0.0.0
 # the TCP port to listen on
 port 8765
 
+# URL Prefix to add, or empty string for root URL (the default).
+# e.g. if URL_PREFIX="/foo", motioneye's UI will be at http://0.0.0.0:8765/foo/
+#url_prefix /foo
+
 # path to the motion binary to use (automatically detected if commented)
 #motion_binary /usr/bin/motion
 

--- a/motioneye/settings.py
+++ b/motioneye/settings.py
@@ -51,6 +51,10 @@ LISTEN = '0.0.0.0'
 # the TCP port to listen on
 PORT = 8765
 
+# URL Prefix to add, or empty string for root URL.
+# e.g. if URL_PREFIX="/foo/", motioneye's UI will be at http://0.0.0.0:8765/foo/
+URL_PREFIX = ""
+
 # path to the motion binary to use (automatically detected by default)
 MOTION_BINARY = None
 


### PR DESCRIPTION
Hello,

I love MotionEye, use it daily on my RPi3.

I needed this feature so that all web activity from the RPi is served through NGINX, and not directly from other ports (e.g. https://rpi/meye/ is motion-eye while https://rpi/foo/ is something else).

Hope you find it useful.
Comments welcomed.
 - gordon

