### PR TITLE
Update config.py

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -38,7 +38,7 @@ import uploadservices
 import utils
 import v4l2ctl
 
-_CAMERA_CONFIG_FILE_NAME = 'thread-%(id)s.conf'
+_CAMERA_CONFIG_FILE_NAME = 'camera-%(id)s.conf'
 _MAIN_CONFIG_FILE_NAME = 'motion.conf'
 _ACTIONS = ['lock', 'unlock', 'light_on', 'light_off', 'alarm_on', 'alarm_off',
             'up', 'right', 'down', 'left', 'zoom_in', 'zoom_out',


### PR DESCRIPTION
Fixed for this error below

[-1976663088:motion] [ALR] [ALL] conf_cmdparse: Deprecated config option "thread" since after version 3.4.1:
[-1976663088:motion] [ALR] [ALL] conf_cmdparse: The "thread" option has been replaced by the "camera" option.