### PR TITLE
Add mosquitto clients & upgrade

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get --quiet update && \
     libmysqlclient20 \
     libpq5 \
     lsb-release \
+    mosquitto-clients \
     python-jinja2 \
     python-pil \
     python-pip \

--- a/extra/Dockerfile.armv7-armhf
+++ b/extra/Dockerfile.armv7-armhf
@@ -24,6 +24,7 @@ RUN apt-get --quiet update && \
     libmariadbclient18 \
     libpq5 \
     lsb-release \
+    mosquitto-clients \
     python-jinja2 \
     python-pil \
     python-pip \


### PR DESCRIPTION
Closes #877 #1076

This PR:
 - adds the MQTT client 'mosquitto' to the docker image
 - Updates motion to 4.2
 - Updates the AMD64 image to Ubuntu 18.04

Tested on AMD64