### PR TITLE
Allow specifying MJPEG:// urls

### DIFF
--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -618,7 +618,7 @@ class ConfigHandler(BaseHandler):
                 else:
                     self.finish_json({'cameras': cameras})
             
-            if scheme in ['http', 'https']:
+            if scheme in ['http', 'https', 'mjpeg']:
                 utils.test_mjpeg_url(self.get_all_arguments(), auth_modes=['basic'], allow_jpeg=True,
                                      callback=on_response)
                 

--- a/motioneye/utils.py
+++ b/motioneye/utils.py
@@ -374,7 +374,7 @@ def test_mjpeg_url(data, auth_modes, allow_jpeg, callback):
     data.setdefault('password', None)
 
     url = '%(scheme)s://%(host)s%(port)s%(path)s' % {
-            'scheme': data['scheme'],
+            'scheme': data['scheme'] if data['scheme'] != 'mjpeg' else 'http',
             'host': data['host'],
             'port': ':' + str(data['port']) if data['port'] else '',
             'path': data['path'] or ''}


### PR DESCRIPTION
ffmjpeg has issues playing certain mjpeg streams, the default settings assume a certain form for the boundary condition which not all mjpeg streams follow. ffmpeg refers to this internally as 'mpjpeg'. ffmpeg is capable of decoding any mjpeg stream provided the `-f mjpeg` command line flag. 

The motion project handles this by allowing a URL to be specified as `mjpeg://`, which it then assumes to be 'http://' with '-f mjpeg' passed to ffmpeg. This PR adds such support to motioneye.