### PR TITLE
upload service provider for Google photo

### DIFF
--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,2 +1,2 @@
 
-VERSION = "0.40rc5"
+VERSION = "0.40rc6"

--- a/motioneye/__init__.py
+++ b/motioneye/__init__.py
@@ -1,2 +1,2 @@
 
-VERSION = "0.40rc6"
+VERSION = "0.40"

--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -1783,6 +1783,7 @@ class RelayEventHandler(BaseHandler):
         
         tasks.add(5, uploadservices.upload_media_file, tag='upload_media_file(%s)' % filename,
                 camera_id=camera_id, service_name=service_name,
+                camera_name=camera_config['camera_name'],
                 target_dir=camera_config['@upload_subfolders'] and camera_config['target_dir'],
                 filename=filename)
 

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -453,7 +453,7 @@
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadLocationEntry"></td>
                             <td><span class="help-mark" title="the location (root path) where media files should be uploaded (e.g. /files/cam1/)">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="uploadEnabled">
+                        <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService!=(gphoto)">
                             <td class="settings-item-label"><span class="settings-item-label">Include Subfolders</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="uploadSubfoldersSwitch"></td>
                             <td><span class="help-mark" title="enable this to upload the media files together with their subfolders, instead of placing them directly into the root location">?</span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -422,6 +422,7 @@
     <!--                                 <option value="http">HTTP Server</option> -->
     <!--                                 <option value="https">HTTPS Server</option> -->
                                     <option value="gdrive">Google Drive</option>
+                                    <option value="gphoto">Google Photo</option>
                                     <option value="dropbox">Dropbox</option>
                                 </select>
                             </td>
@@ -472,12 +473,12 @@
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadPasswordEntry"></td>
                             <td><span class="help-mark" title="the password for the upload service account">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService=(gdrive|dropbox)">
+                        <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService=(gdrive|gphoto|dropbox)">
                             <td class="settings-item-label"><span class="settings-item-label">Authorization Key</span></td>
                             <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadAuthorizationKeyEntry"></td>
                             <td><span class="help-mark" title="the key used to authenticate with the upload service (normally required only during setup)">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService=(gdrive|dropbox)">
+                        <tr class="settings-item advanced-setting" depends="uploadEnabled uploadService=(gdrive|gphoto|dropbox)">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
                             <td class="settings-item-value">
                                 <div class="html styled storage camera-config" id="authorizeLinkHtml">

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -497,6 +497,321 @@ class GoogleDrive(UploadService):
         return self._get_file_metadata(file_id)['title']
 
 
+class GooglePhoto(UploadService):
+    NAME = 'gphoto'
+
+    AUTH_URL = 'https://accounts.google.com/o/oauth2/auth'
+    TOKEN_URL = 'https://accounts.google.com/o/oauth2/token'
+
+    CLIENT_ID = '349038943026-m16svdadjrqc0c449u4qv71v1m1niu5o.apps.googleusercontent.com'
+    CLIENT_NOT_SO_SECRET = 'jjqbWmICpA0GvbhsJB3okX7s'
+
+    SCOPE = 'https://www.googleapis.com/auth/photoslibrary'
+    GOOGLE_PHOTO_API = 'https://photoslibrary.googleapis.com/v1/'
+    CHILDREN_URL = 'https://www.googleapis.com/drive/v2/files/%(parent_id)s/children?q=%(query)s'
+    CHILDREN_QUERY = "'%(parent_id)s' in parents and title = '%(child_name)s' and trashed = false"
+    UPLOAD_URL = 'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
+    CREATE_FOLDER_URL = 'https://www.googleapis.com/drive/v2/files'
+
+    BOUNDARY = 'motioneye_multipart_boundary'
+
+    FOLDER_ID_LIFE_TIME = 300  # 5 minutes
+
+    def __init__(self, camera_id):
+        self._location = None
+        self._authorization_key = None
+        self._credentials = None
+        self._folder_ids = {}
+        self._folder_id_times = {}
+
+        UploadService.__init__(self, camera_id)
+
+    @classmethod
+    def get_authorize_url(cls):
+        query = {
+            'scope': cls.SCOPE,
+            'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+            'response_type': 'code',
+            'client_id': cls.CLIENT_ID,
+            'access_type': 'offline'
+        }
+
+        return cls.AUTH_URL + '?' + urllib.urlencode(query)
+
+    def test_access(self):
+        try:
+            self._folder_ids = {}
+            #self._get_folder_id()
+            self._get_albums()
+            return True
+
+        except Exception as e:
+            return str(e)
+
+    def upload_data(self, filename, mime_type, data):
+        path = os.path.dirname(filename)
+        filename = os.path.basename(filename)
+
+        metadata = {
+            'title': filename,
+            'parents': [{'id': self._get_folder_id(path)}]
+        }
+
+        body = ['--' + self.BOUNDARY]
+        body.append('Content-Type: application/json; charset=UTF-8')
+        body.append('')
+        body.append(json.dumps(metadata))
+        body.append('')
+
+        body.append('--' + self.BOUNDARY)
+        body.append('Content-Type: %s' % mime_type)
+        body.append('')
+        body.append('')
+        body = '\r\n'.join(body)
+        body += data
+        body += '\r\n--%s--' % self.BOUNDARY
+
+        headers = {
+            'Content-Type': 'multipart/related; boundary="%s"' % self.BOUNDARY,
+            'Content-Length': len(body)
+        }
+
+        self._request(self.UPLOAD_URL, body, headers)
+
+    def dump(self):
+        return {
+            'location': self._location,
+            'credentials': self._credentials,
+            'authorization_key': self._authorization_key,
+        }
+
+    def load(self, data):
+        if data.get('location'):
+            self._location = data['location']
+            self._folder_ids = {}
+        if data.get('authorization_key'):
+            self._authorization_key = data['authorization_key']
+            self._credentials = None
+        if data.get('credentials'):
+            self._credentials = data['credentials']
+
+    def _get_folder_id(self, path=''):
+        now = time.time()
+
+        folder_id = self._folder_ids.get(path)
+        folder_id_time = self._folder_id_times.get(path, 0)
+
+        location = self._location
+        if not location.endswith('/'):
+            location += '/'
+
+        location += path
+
+        if not folder_id or (now - folder_id_time > self.FOLDER_ID_LIFE_TIME):
+            self.debug('finding folder id for location "%s"' % location)
+            folder_id = self._get_folder_id_by_path(location)
+
+            self._folder_ids[path] = folder_id
+            self._folder_id_times[path] = now
+
+        return folder_id
+
+    def _get_folder_id_by_path(self, path):
+        if path and path != '/':
+            path = [p.strip() for p in path.split('/') if p.strip()]
+            parent_id = 'root'
+            for name in path:
+                parent_id = self._get_folder_id_by_name(parent_id, name)
+
+            return parent_id
+
+        else:  # root folder
+            return self._get_folder_id_by_name(None, 'root')
+
+    def _get_folder_id_by_name(self, parent_id, child_name, create=True):
+        if parent_id:
+            query = self.CHILDREN_QUERY % {'parent_id': parent_id, 'child_name': child_name}
+            query = urllib.quote(query)
+
+        else:
+            query = ''
+
+        parent_id = parent_id or 'root'
+        # when requesting the id of the root folder, we perform a dummy request,
+        # event though we already know the id (which is "root"), to test the request
+
+        url = self.CHILDREN_URL % {'parent_id': parent_id, 'query': query}
+        response = self._request(url)
+        try:
+            response = json.loads(response)
+
+        except Exception:
+            self.error("response doesn't seem to be a valid json")
+            raise
+
+        if parent_id == 'root' and child_name == 'root':
+            return 'root'
+
+        items = response.get('items')
+        if not items:
+            if create:
+                self.debug('folder with name "%s" does not exist, creating it' % child_name)
+                self._create_folder(parent_id, child_name)
+                return self._get_folder_id_by_name(parent_id, child_name, create=False)
+
+            else:
+                msg = 'folder with name "%s" does not exist' % child_name
+                self.error(msg)
+                raise Exception(msg)
+
+        return items[0]['id']
+
+    def _create_folder(self, parent_id, child_name):
+        metadata = {
+            'title': child_name,
+            'parents': [{'id': parent_id}],
+            'mimeType': 'application/vnd.google-apps.folder'
+        }
+
+        body = json.dumps(metadata)
+
+        headers = {
+            'Content-Type': 'application/json; charset=UTF-8'
+        }
+
+        self._request(self.CREATE_FOLDER_URL, body, headers)
+
+    def _get_albums(self):
+        response = self._request(self.GOOGLE_PHOTO_API + 'albums')
+        try:
+            response = json.loads(response)
+
+        except Exception:
+            self.error("response doesn't seem to be a valid json")
+            raise
+
+        albums = response.get('albums')
+        self.debug('got %s album(s)' % len(albums))
+        return albums
+
+    def _request(self, url, body=None, headers=None, retry_auth=True, method=None):
+        if not self._credentials:
+            if not self._authorization_key:
+                msg = 'missing authorization key'
+                self.error(msg)
+                raise Exception(msg)
+
+            self.debug('requesting credentials')
+            try:
+                self._credentials = self._request_credentials(self._authorization_key)
+                self.save()
+
+            except Exception as e:
+                self.error('failed to obtain credentials: %s' % e)
+                raise
+
+        headers = headers or {}
+        headers['Authorization'] = 'Bearer %s' % self._credentials['access_token']
+
+        self.debug('requesting %s' % url)
+        request = urllib2.Request(url, data=body, headers=headers)
+        if method:
+            request.get_method = lambda: method
+        try:
+            response = utils.urlopen(request)
+
+        except urllib2.HTTPError as e:
+            if e.code == 401 and retry_auth:  # unauthorized, access token may have expired
+                try:
+                    self.debug('credentials have probably expired, refreshing them')
+                    self._credentials = self._refresh_credentials(self._credentials['refresh_token'])
+                    self.save()
+
+                    # retry the request with refreshed credentials
+                    return self._request(url, body, headers, retry_auth=False)
+
+                except Exception:
+                    self.error('refreshing credentials failed')
+                    raise
+
+            else:
+                try:
+                    e = json.load(e)
+                    msg = e['error']['message']
+
+                except Exception:
+                    msg = str(e)
+
+                self.error('request failed: %s' % msg)
+                raise Exception(msg)
+
+        except Exception as e:
+            self.error('request failed: %s' % e)
+            raise
+
+        return response.read()
+
+    def _request_credentials(self, authorization_key):
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+
+        body = {
+            'code': authorization_key,
+            'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+            'client_id': self.CLIENT_ID,
+            'client_secret': self.CLIENT_NOT_SO_SECRET,
+            'scope': self.SCOPE,
+            'grant_type': 'authorization_code'
+        }
+        body = urllib.urlencode(body)
+
+        request = urllib2.Request(self.TOKEN_URL, data=body, headers=headers)
+
+        try:
+            response = utils.urlopen(request)
+
+        except urllib2.HTTPError as e:
+            error = json.load(e)
+            raise Exception(error.get('error_description') or error.get('error') or str(e))
+
+        data = json.load(response)
+
+        return {
+            'access_token': data['access_token'],
+            'refresh_token': data['refresh_token']
+        }
+
+    def _refresh_credentials(self, refresh_token):
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+
+        body = {
+            'refresh_token': refresh_token,
+            'client_id': self.CLIENT_ID,
+            'client_secret': self.CLIENT_NOT_SO_SECRET,
+            'grant_type': 'refresh_token'
+        }
+        body = urllib.urlencode(body)
+
+        request = urllib2.Request(self.TOKEN_URL, data=body, headers=headers)
+
+        try:
+            response = utils.urlopen(request)
+
+        except urllib2.HTTPError as e:
+            error = json.load(e)
+            raise Exception(error.get('error_description') or error.get('error') or str(e))
+
+        data = json.load(response)
+
+        return {
+            'access_token': data['access_token'],
+            'refresh_token': data.get('refresh_token', refresh_token)
+        }
+
+
 class Dropbox(UploadService):
     NAME = 'dropbox'
 

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -150,6 +150,51 @@ class GoogleBase:
     CLIENT_ID = '349038943026-m16svdadjrqc0c449u4qv71v1m1niu5o.apps.googleusercontent.com'
     CLIENT_NOT_SO_SECRET = 'jjqbWmICpA0GvbhsJB3okX7s'
 
+    def _init(self):
+        self._location = None
+        self._authorization_key = None
+        self._credentials = None
+        self._folder_ids = {}
+        self._folder_id_times = {}
+
+    @classmethod
+    def _get_authorize_url(cls):
+        query = {
+            'scope': cls.SCOPE,
+            'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+            'response_type': 'code',
+            'client_id': cls.CLIENT_ID,
+            'access_type': 'offline'
+        }
+
+        return cls.AUTH_URL + '?' + urllib.urlencode(query)
+
+    def _test_access(self):
+        try:
+            self._folder_ids = {}
+            self._get_folder_id()
+            return True
+
+        except Exception as e:
+            return str(e)
+
+    def _dump(self):
+        return {
+            'location': self._location,
+            'credentials': self._credentials,
+            'authorization_key': self._authorization_key,
+        }
+
+    def _load(self, data):
+        if data.get('location'):
+            self._location = data['location']
+            self._folder_ids = {}
+        if data.get('authorization_key'):
+            self._authorization_key = data['authorization_key']
+            self._credentials = None
+        if data.get('credentials'):
+            self._credentials = data['credentials']
+
     def _request(self, url, body=None, headers=None, retry_auth=True, method=None):
         if not self._credentials:
             if not self._authorization_key:
@@ -292,34 +337,16 @@ class GoogleDrive(UploadService, GoogleBase):
     FOLDER_ID_LIFE_TIME = 300  # 5 minutes
 
     def __init__(self, camera_id):
-        self._location = None
-        self._authorization_key = None
-        self._credentials = None
-        self._folder_ids = {}
-        self._folder_id_times = {}
+        self._init()
 
         UploadService.__init__(self, camera_id)
 
     @classmethod
     def get_authorize_url(cls):
-        query = {
-            'scope': cls.SCOPE,
-            'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
-            'response_type': 'code',
-            'client_id': cls.CLIENT_ID,
-            'access_type': 'offline'
-        }
-
-        return cls.AUTH_URL + '?' + urllib.urlencode(query)
+        return cls._get_authorize_url()
 
     def test_access(self):
-        try:
-            self._folder_ids = {}
-            self._get_folder_id()
-            return True
-
-        except Exception as e:
-            return str(e)
+        return self._test_access()
 
     def upload_data(self, filename, mime_type, data, ctime, camera_name):
         path = os.path.dirname(filename)
@@ -352,21 +379,10 @@ class GoogleDrive(UploadService, GoogleBase):
         self._request(self.UPLOAD_URL, body, headers)
 
     def dump(self):
-        return {
-            'location': self._location,
-            'credentials': self._credentials,
-            'authorization_key': self._authorization_key,
-        }
+        return self._dump()
 
     def load(self, data):
-        if data.get('location'):
-            self._location = data['location']
-            self._folder_ids = {}
-        if data.get('authorization_key'):
-            self._authorization_key = data['authorization_key']
-            self._credentials = None
-        if data.get('credentials'):
-            self._credentials = data['credentials']
+        self._load(data)
 
     def _get_folder_id(self, path=''):
         now = time.time()
@@ -519,34 +535,16 @@ class GooglePhoto(UploadService, GoogleBase):
     GOOGLE_PHOTO_API = 'https://photoslibrary.googleapis.com/v1/'
 
     def __init__(self, camera_id):
-        self._location = None
-        self._authorization_key = None
-        self._credentials = None
-        self._folder_ids = {}
-        self._folder_id_times = {}
+        self._init()
 
         UploadService.__init__(self, camera_id)
 
     @classmethod
     def get_authorize_url(cls):
-        query = {
-            'scope': cls.SCOPE,
-            'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
-            'response_type': 'code',
-            'client_id': cls.CLIENT_ID,
-            'access_type': 'offline'
-        }
-
-        return cls.AUTH_URL + '?' + urllib.urlencode(query)
+        return cls._get_authorize_url()
 
     def test_access(self):
-        try:
-            self._folder_ids = {}
-            self._get_folder_id()
-            return True
-
-        except Exception as e:
-            return str(e)
+        return self._test_access()
 
     def upload_data(self, filename, mime_type, data, ctime, camera_name):
         path = os.path.dirname(filename)
@@ -567,21 +565,10 @@ class GooglePhoto(UploadService, GoogleBase):
         self.debug('response %s' % response['mediaItem'])
 
     def dump(self):
-        return {
-            'location': self._location,
-            'credentials': self._credentials,
-            'authorization_key': self._authorization_key,
-        }
+        return self._dump()
 
     def load(self, data):
-        if data.get('location'):
-            self._location = data['location']
-            self._folder_ids = {}
-        if data.get('authorization_key'):
-            self._authorization_key = data['authorization_key']
-            self._credentials = None
-        if data.get('credentials'):
-            self._credentials = data['credentials']
+        self._load(data)
 
     def _get_folder_id(self, path=''):
         location = self._location


### PR DESCRIPTION
Fixes #1212. When Google Photo selected, it hides `Clean Cloud` and `Include Subfolders` options and all media files will be stored in an album named by the value from `Location` field. Also each media filename will be prefixed with day info coming from a creation time, e.g. `2019-04-07-13-20-37.mp4`.