### PR TITLE
Making sha-bang more portable

### DIFF
--- a/motioneye/scripts/relayevent.sh
+++ b/motioneye/scripts/relayevent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$3" ]; then
     echo "Usage: $0 <motioneye.conf> <event> <motion_camera_id> [filename]"


### PR DESCRIPTION
'/usr/bin/env bash' for sha-bang makes the script more portable. It does not break any of the existing supported Linux platform, but now it, also, works on FreeBSD.  