### PR TITLE
Add support for privacy mask

### DIFF
--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -476,7 +476,7 @@ input[type=text].working-schedule.number {
     width: 90%;
 }
 
-#maskLinesEntry {
+#motionMaskLinesEntry, #privacyMaskLinesEntry {
     display: none;
 }
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -877,24 +877,22 @@ function initUI() {
         }
     });
     
-    /* disable mask editor when mask gets disabled */
-    $('#maskSwitch').change(function () {
+    /* disable corresponding mask editor when the mask gets disabled */
+    $('#motionMaskSwitch').change(function () {
        if (!this.checked) {
-           disableMaskEdit();
+            disableMaskEdit('motion');
        } 
     });
-    
-    /* disable mask editor when mask gets disabled */
-    $('#maskSwitch').change(function () {
-       if (!this.checked) {
-           disableMaskEdit();
-       } 
-    });
-    
-    /* disable mask editor when mask type is no longer editable */
-    $('#maskTypeSelect').change(function () {
+    $('#privacyMaskSwitch').change(function () {
+        if (!this.checked) {
+             disableMaskEdit('privacy');
+        } 
+     });
+     
+    /* disable motion detection mask editor when mask type is no longer editable */
+    $('#motionMaskTypeSelect').change(function () {
         if ($(this).val() != 'editable') {
-            disableMaskEdit();
+            disableMaskEdit('motion');
         }
     });
     
@@ -936,19 +934,20 @@ function initUI() {
     $('div#networkShareTestButton').click(doTestNetworkShare);
     
     /* mask editor buttons */
-    $('div#editMaskButton').click(function () {
+    $('div#motionMaskEditButton, div#privacyMaskEditButton').click(function (event) {
         var cameraId = $('#cameraSelect').val();
         var img = getCameraFrame(cameraId).find('img.camera')[0];
         if (!img._naturalWidth || !img._naturalHeight) {
             return runAlertDialog('Cannot edit the mask without a valid camera image!');
         }
 
-        enableMaskEdit(cameraId, img._naturalWidth, img._naturalHeight);
+        const maskClass = event.target.id.substring(0, event.target.id.indexOf('MaskEditButton'));
+        enableMaskEdit(cameraId, maskClass, img._naturalWidth, img._naturalHeight);
     });
-    $('div#saveMaskButton').click(function () {
+    $('div#motionMaskSaveButton, div#privacyMaskSaveButton').click(function () {
         disableMaskEdit();
     });
-    $('div#clearMaskButton').click(function () {
+    $('div#motionMaskClearButton, div#privacyMaskClearButton').click(function () {
         var cameraId = $('#cameraSelect').val();
         if (!cameraId) {
             return;
@@ -1122,7 +1121,7 @@ function hideCameraOverlay() {
     disableMaskEdit();
 }
 
-function enableMaskEdit(cameraId, width, height) {
+function enableMaskEdit(cameraId, maskClass, width, height) {
     var cameraFrame = getCameraFrame(cameraId);
     var overlayDiv = cameraFrame.find('div.camera-overlay');
     var maskDiv = cameraFrame.find('div.camera-overlay-mask');
@@ -1209,7 +1208,7 @@ function enableMaskEdit(cameraId, width, height) {
             maskLines.push(line);
         }
         
-        $('#maskLinesEntry').val(maskLines.join(',')).change();
+        $('#'+maskClass+'MaskLinesEntry').val(maskLines.join(',')).change();
     }
     
     function handleMouseUp() {
@@ -1288,7 +1287,7 @@ function enableMaskEdit(cameraId, width, height) {
     
     /* use mask lines to initialize the element matrix */
     var line;
-    var maskLines = $('#maskLinesEntry').val() ? $('#maskLinesEntry').val().split(',').map(function (v) {return parseInt(v);}) : [];
+    var maskLines = $('#'+maskClass+'MaskLinesEntry').val() ? $('#'+maskClass+'MaskLinesEntry').val().split(',').map(function (v) {return parseInt(v);}) : [];
     maskLines = maskLines.slice(2);
 
     for (y = 0; y < ny; y++) {
@@ -1318,8 +1317,8 @@ function enableMaskEdit(cameraId, width, height) {
 
     var selectedCameraId = $('#cameraSelect').val();
     if (selectedCameraId && (!cameraId || cameraId == selectedCameraId)) {
-        $('#saveMaskButton, #clearMaskButton').css('display', 'inline-block');
-        $('#editMaskButton').css('display', 'none');
+        $('#'+maskClass+'MaskSaveButton, #'+maskClass+'MaskClearButton').css('display', 'inline-block');
+        $('#'+maskClass+'MaskEditButton').css('display', 'none');
     }
     
     if (!overlayVisible) {
@@ -1327,14 +1326,25 @@ function enableMaskEdit(cameraId, width, height) {
     }
 }
 
-function disableMaskEdit(cameraId) {
-    var cameraFrames;
-    if (cameraId) {
-        cameraFrames = [getCameraFrame(cameraId)];
+function disableMaskEdit(maskClass) {
+    if (!maskClass) {
+        /* disable mask editor regardless of the mask class */
+        disableMaskOverlay();
+        $('.edit-mask-button').css('display', 'inline-block');
+        $('.save-mask-button, .clear-mask-button').css('display', 'none');
+    } else {
+        if ($('#'+maskClass+'MaskSaveButton').css('display') !== 'none') {
+            /* only disable mask overlay if it is for the same mask class*/
+            disableMaskOverlay();
+        }
+        $('#'+maskClass+'MaskEditButton').css('display', 'inline-block');
+        $('#'+maskClass+'MaskSaveButton, #'+maskClass+'MaskClearButton').css('display', 'none');
     }
-    else { /* disable mask editor on any camera */
-        cameraFrames = getCameraFrames().toArray().map(function (f) {return $(f);});
-    }
+}
+
+function disableMaskOverlay() {
+    /* disable mask overlay on any camera */
+    var  cameraFrames = getCameraFrames().toArray().map(function (f) {return $(f);});
 
     cameraFrames.forEach(function (cameraFrame) {
         var overlayDiv = cameraFrame.find('div.camera-overlay');
@@ -1344,12 +1354,6 @@ function disableMaskEdit(cameraId) {
         maskDiv.html('');
         maskDiv.unbind('click');
     });
-    
-    var selectedCameraId = $('#cameraSelect').val();
-    if (selectedCameraId && (!cameraId || cameraId == selectedCameraId)) {
-        $('#editMaskButton').css('display', 'inline-block');
-        $('#saveMaskButton, #clearMaskButton').css('display', 'none');
-    }
 }
 
 function clearMask(cameraId) {
@@ -1857,6 +1861,8 @@ function cameraUi2Dict() {
         'auto_brightness': $('#autoBrightnessSwitch')[0].checked,
         'rotation': $('#rotationSelect').val(),
         'framerate': $('#framerateSlider').val(),
+        'privacy_mask': $('#privacyMaskSwitch')[0].checked,
+        'privacy_mask_lines': $('#privacyMaskLinesEntry').val() ? $('#privacyMaskLinesEntry').val().split(',').map(function (l) {return parseInt(l);}) : [],
         'extra_options': $('#extraOptionsEntry').val().split(new RegExp('(\n)|(\r\n)|(\n\r)')).map(function (o) {
             if (!o) {
                 return null;
@@ -1953,10 +1959,10 @@ function cameraUi2Dict() {
         'pre_capture': $('#preCaptureEntry').val(),
         'post_capture': $('#postCaptureEntry').val(),
         'minimum_motion_frames': $('#minimumMotionFramesEntry').val(),
-        'mask': $('#maskSwitch')[0].checked,
-        'mask_type': $('#maskTypeSelect').val(),
+        'motion_mask': $('#motionMaskSwitch')[0].checked,
+        'motion_mask_type': $('#motionMaskTypeSelect').val(),
         'smart_mask_sluggishness': $('#smartMaskSluggishnessSlider').val(),
-        'mask_lines': $('#maskLinesEntry').val() ? $('#maskLinesEntry').val().split(',').map(function (l) {return parseInt(l);}) : [],
+        'motion_mask_lines': $('#motionMaskLinesEntry').val() ? $('#motionMaskLinesEntry').val().split(',').map(function (l) {return parseInt(l);}) : [],
         'show_frame_changes': $('#showFrameChangesSwitch')[0].checked,
         'create_debug_media': $('#createDebugMediaSwitch')[0].checked,
 
@@ -2153,6 +2159,8 @@ function dict2CameraUi(dict) {
     
     $('#rotationSelect').val(dict['rotation']); markHideIfNull('rotation', 'rotationSelect');
     $('#framerateSlider').val(dict['framerate']); markHideIfNull('framerate', 'framerateSlider');
+    $('#privacyMaskSwitch')[0].checked = dict['privacy_mask']; markHideIfNull('privacy_mask', 'privacyMaskSwitch');
+    $('#privacyMaskLinesEntry').val((dict['privacy_mask_lines'] || []).join(',')); markHideIfNull('privacy_mask_lines', 'privacyMaskLinesEntry');
     $('#extraOptionsEntry').val(dict['extra_options'] ? (dict['extra_options'].map(function (o) {
         return o.join(' ');
     }).join('\r\n')) : ''); markHideIfNull('extra_options', 'extraOptionsEntry');
@@ -2317,10 +2325,10 @@ function dict2CameraUi(dict) {
     $('#preCaptureEntry').val(dict['pre_capture']); markHideIfNull('pre_capture', 'preCaptureEntry');
     $('#postCaptureEntry').val(dict['post_capture']); markHideIfNull('post_capture', 'postCaptureEntry');
     $('#minimumMotionFramesEntry').val(dict['minimum_motion_frames']); markHideIfNull('minimum_motion_frames', 'minimumMotionFramesEntry');
-    $('#maskSwitch')[0].checked = dict['mask']; markHideIfNull('mask', 'maskSwitch');
-    $('#maskTypeSelect').val(dict['mask_type']); markHideIfNull('mask_type', 'maskTypeSelect');
+    $('#motionMaskSwitch')[0].checked = dict['motion_mask']; markHideIfNull('motion_mask', 'motionMaskSwitch');
+    $('#motionMaskTypeSelect').val(dict['motion_mask_type']); markHideIfNull('motion_mask_type', 'motionMaskTypeSelect');
     $('#smartMaskSluggishnessSlider').val(dict['smart_mask_sluggishness']); markHideIfNull('smart_mask_sluggishness', 'smartMaskSluggishnessSlider');
-    $('#maskLinesEntry').val((dict['mask_lines'] || []).join(',')); markHideIfNull('mask_lines', 'maskLinesEntry');
+    $('#motionMaskLinesEntry').val((dict['motion_mask_lines'] || []).join(',')); markHideIfNull('motion_mask_lines', 'motionMaskLinesEntry');
     $('#showFrameChangesSwitch')[0].checked = dict['show_frame_changes']; markHideIfNull('show_frame_changes', 'showFrameChangesSwitch');
     $('#createDebugMediaSwitch')[0].checked = dict['create_debug_media']; markHideIfNull('create_debug_media', 'createDebugMediaSwitch');
 

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -318,6 +318,31 @@
                             <td><span class="help-mark" title="sets the number of frames captured by the camera every second (higher values produce smoother videos but require more CPU power, larger storage space and bandwidth)">?</span></td>
                         </tr>
                         <tr class="settings-item advanced-setting">
+                            <td colspan="100"><div class="settings-item-separator"></div></td>
+                        </tr>
+                        <tr class="settings-item advanced-setting">
+                            <td class="settings-item-label"><span class="settings-item-label">Privacy Mask</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="privacyMaskSwitch"></td>
+                            <td><span class="help-mark" title="enables image masking to prevent some image areas from being recorded to protect privacy">?</span></td>
+                        </tr>
+                        <tr class="settings-item advanced-setting" depends="privacyMask">
+                            <td class="settings-item-label"><span class="settings-item-label"></span></td>
+                            <td class="settings-item-value">
+                                <div class="button normal-button edit-mask-button" id="privacyMaskEditButton">Edit Mask</div>
+                                <div class="button normal-button save-mask-button" id="privacyMaskSaveButton">Save Mask</div>
+                                <input type="text" class="device camera-config" id="privacyMaskLinesEntry">
+                            </td>
+                            <td><span class="help-mark" title="click this button to enable/disable the mask editor">?</span></td>
+                        </tr>
+                        <tr class="settings-item advanced-setting" depends="privacyMask">
+                            <td class="settings-item-label"><span class="settings-item-label"></span></td>
+                            <td class="settings-item-value"><div class="button normal-button clear-mask-button" id="privacyMaskClearButton">Clear Mask</div></td>
+                            <td><span class="help-mark" title="click this button to clear the current mask">?</span></td>
+                        </tr>
+                        <tr class="settings-item advanced-setting">
+                            <td colspan="100"><div class="settings-item-separator"></div></td>
+                        </tr>
+                        <tr class="settings-item advanced-setting">
                             <td class="settings-item-label"><span class="settings-item-label">Extra Motion Options</span></td>
                             <td class="settings-item-value"><textarea class="styled device camera-config" id="extraOptionsEntry" rows="3"></textarea></td>
                             <td><span class="help-mark" title="you can add here any extra options for the motion daemon (use the &quot;name value&quot; format, one option per line)">?</span></td>
@@ -878,37 +903,37 @@
                             <td colspan="100"><div class="settings-item-separator"></div></td>
                         </tr>
                         <tr class="settings-item advanced-setting">
-                            <td class="settings-item-label"><span class="settings-item-label">Mask</span></td>
-                            <td class="settings-item-value"><input type="checkbox" class="styled motion-detection camera-config" id="maskSwitch"></td>
+                            <td class="settings-item-label"><span class="settings-item-label">Motion Detection Mask</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled motion-detection camera-config" id="motionMaskSwitch"></td>
                             <td><span class="help-mark" title="enables image masking for a more selective and precise motion detection">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="mask">
+                        <tr class="settings-item advanced-setting" depends="motionMask">
                             <td class="settings-item-label"><span class="settings-item-label">Mask Type</span></td>
                             <td class="settings-item-value">
-                                <select class="styled motion-detection camera-config" id="maskTypeSelect">
+                                <select class="styled motion-detection camera-config" id="motionMaskTypeSelect">
                                     <option value="smart">Smart</option>
                                     <option value="editable">Editable</option>
                                 </select>
                             </td>
                             <td><span class="help-mark" title="the smart option automatically detects regions with regular motion and dynamically builds an internal mask, while the editable mask allows you to manually build it yourself">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" min="1" max="10" snap="1" ticksnum="10" decimals="0" unit="" depends="mask maskType=smart">
+                        <tr class="settings-item advanced-setting" min="1" max="10" snap="1" ticksnum="10" decimals="0" unit="" depends="motionMask motionMaskType=smart">
                             <td class="settings-item-label"><span class="settings-item-label">Smart Mask Sluggishness</span></td>
                             <td class="settings-item-value"><input type="text" class="range styled motion-detection camera-config" id="smartMaskSluggishnessSlider"></td>
                             <td><span class="help-mark" title="lower values result in a longer-lasting smart mask with a slower building process">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="mask maskType=editable">
+                        <tr class="settings-item advanced-setting" depends="motionMask motionMaskType=editable">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
                             <td class="settings-item-value">
-                                <div class="button normal-button edit-mask-button" id="editMaskButton">Edit Mask</div>
-                                <div class="button normal-button save-mask-button" id="saveMaskButton">Save Mask</div>
-                                <input type="text" class="motion-detection camera-config" id="maskLinesEntry">
+                                <div class="button normal-button edit-mask-button" id="motionMaskEditButton">Edit Mask</div>
+                                <div class="button normal-button save-mask-button" id="motionMaskSaveButton">Save Mask</div>
+                                <input type="text" class="motion-detection camera-config" id="motionMaskLinesEntry">
                             </td>
                             <td><span class="help-mark" title="click this button to enable/disable the mask editor">?</span></td>
                         </tr>
-                        <tr class="settings-item advanced-setting" depends="mask maskType=editable">
+                        <tr class="settings-item advanced-setting" depends="motionMask motionMaskType=editable">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
-                            <td class="settings-item-value"><div class="button normal-button clear-mask-button" id="clearMaskButton">Clear Mask</div></td>
+                            <td class="settings-item-value"><div class="button normal-button clear-mask-button" id="motionMaskClearButton">Clear Mask</div></td>
                             <td><span class="help-mark" title="click this button to clear the current mask">?</span></td>
                         </tr>
                         <tr class="settings-item advanced-setting">

--- a/motioneye/utils.py
+++ b/motioneye/utils.py
@@ -817,7 +817,7 @@ def urlopen(*args, **kwargs):
     return urllib2.urlopen(*args, **kwargs)
 
 
-def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_height=None):
+def build_editable_mask_file(camera_id, mask_class, mask_lines, capture_width=None, capture_height=None):
     if not mask_lines:
         return ''
     
@@ -825,8 +825,8 @@ def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_
     height = mask_lines[1]
     mask_lines = mask_lines[2:]
     
-    logging.debug('building editable mask for camera with id %s (%sx%s)' %
-                  (camera_id, width, height))
+    logging.debug('building editable %s mask for camera with id %s (%sx%s)' %
+                  (mask_class, camera_id, width, height))
 
     # horizontal rectangles
     nx = MASK_WIDTH  # number of rectangles
@@ -884,7 +884,7 @@ def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_
         if rx and line & 1:
             dr.rectangle((nx * rw, ny * rh, nx * rw + rx - 1, ny * rh + ry - 1), fill=0)
 
-    file_name = os.path.join(settings.CONF_PATH, 'mask_%s.pgm' % camera_id)
+    file_name = build_mask_file_name(camera_id, mask_class)
     
     # resize the image if necessary
     if capture_width and capture_height and im.size != (capture_width, capture_height):
@@ -897,15 +897,20 @@ def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_
 
     return file_name
 
+def build_mask_file_name(camera_id, mask_class):
+    file_name = 'mask_%s.pgm' % (camera_id) if mask_class == 'motion' else 'mask_%s_%s.pgm' % (camera_id, mask_class)
+    full_path = os.path.join(settings.CONF_PATH, file_name)
 
-def parse_editable_mask_file(camera_id, capture_width=None, capture_height=None):
+    return full_path
+
+def parse_editable_mask_file(camera_id, mask_class, capture_width=None, capture_height=None):
     # capture_width and capture_height arguments represent the current size
     # of the camera image, as it might be different from that of the associated mask;
     # they can be null (e.g. netcams)
 
-    file_name = os.path.join(settings.CONF_PATH, 'mask_%s.pgm' % camera_id)
+    file_name = build_mask_file_name(camera_id, mask_class)
 
-    logging.debug('parsing editable mask for camera with id %s: %s' % (camera_id, file_name))
+    logging.debug('parsing editable mask %s for camera with id %s: %s' % (mask_class, camera_id, file_name))
 
     # read the image file
     try:


### PR DESCRIPTION
This is my proposal for implementing support for privacy masks in motionEye (fixes #1193). The new Privacy Mask related settings are located in Video Device section using similar controls as with motion detection masks. To avoid the need for migrating config dir contents I wanted to keep the original motion detection mask file naming intact even though otherwise I renamed mask stuff with "motion" or "privacy" to avoid confusing the two.