### PR TITLE
Declare when the configuration comes from the cache

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -421,6 +421,7 @@ def get_camera(camera_id, as_lines=False):
         return None
 
     _camera_config_cache[camera_id] = dict(camera_config)
+    _camera_config_cache[camera_id]['config_from_cache'] = 1
 
     return camera_config
 


### PR DESCRIPTION
This adds a boolean to the camera configuration when we store it into 
the cache. For all camera configurations, you can easily tell if it is 
the cached configuration or if it is a fresh (non-cached) config based on 
the presence of this boolean