### PR TITLE
Work around deficiencies with unicode in shlex

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1379,7 +1379,7 @@ def motion_camera_dict_to_ui(data):
     command_notifications = []
     for e in on_event_start:
         if e.count(' sendmail '):
-            e = shlex.split(e)
+            e = shlex.split(utils.make_str(e)) # poor shlex can't deal with unicode properly
 
             if len(e) < 10:
                 continue
@@ -1403,7 +1403,7 @@ def motion_camera_dict_to_ui(data):
                 ui['email_notifications_picture_time_span'] = 0
 
         elif e.count(' webhook '):
-            e = shlex.split(e)
+            e = shlex.split(utils.make_str(e)) # poor shlex can't deal with unicode properly
 
             if len(e) < 3:
                 continue
@@ -1447,7 +1447,7 @@ def motion_camera_dict_to_ui(data):
     command_storage = []
     for e in on_movie_end:
         if e.count(' webhook '):
-            e = shlex.split(e)
+            e = shlex.split(utils.make_str(e)) # poor shlex can't deal with unicode properly
 
             if len(e) < 3:
                 continue


### PR DESCRIPTION
Fixes #1321. It seems shlex is not good with unicode. I'm not quite sure if this would not be necessary at all if we were on Python 3.

I noticed that non-ascii in root dir or image file names is not that good, either, but I would take another approach with that so I left it out of this PR.
