### PR TITLE
Fix Google Drive cleanup so it doesn't leave orphaned files behind

### DIFF
--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -485,7 +485,7 @@ class GoogleDrive(UploadService, GoogleBase):
             name = self._get_file_title(id)
             self.debug("cloud '%s'" % name)
             to_delete = not exist_in_local(name, local_folders)
-            if to_delete and self._delete_child(folder_id, id):
+            if to_delete and self._delete_file(id):
                 removed_count += 1
                 self.info("deleted a cloud folder '%s'" % name)
 
@@ -505,8 +505,8 @@ class GoogleDrive(UploadService, GoogleBase):
 
         return response['items']
 
-    def _delete_child(self, folder_id, child_id):
-        url = '%s/%s/children/%s' % (self.CREATE_FOLDER_URL, folder_id, child_id)
+    def _delete_file(self, file_id):
+        url = '%s/%s' % (self.CREATE_FOLDER_URL, file_id)
         response = self._request(url, None, None, True, 'DELETE')
         succeeded = response == ""
         return succeeded


### PR DESCRIPTION
The current cloud cleanup for Google Drive appears to delete files, but in fact it leaves them orphaned: it removes the old folder as a child of the root, but this doesn't delete its files, or even delete the folder. It makes it invisible, but the files still take up storage space.

To confirm this, look at the web page showing items taking up storage space, and you'll see the supposedly deleted files still there. Before too long, you run out of space entirely.

This PR fixes it by deleting the folder rather than just removing it from its parent.