### PR TITLE
future: add motion movie_passthrough option

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -69,6 +69,7 @@ _USED_MOTION_OPTIONS = {
     'movie_output_motion',
     'movie_output',
     'movie_quality',
+    'movie_passthrough',
     'minimum_motion_frames',
     'mmalcam_name',
     'netcam_keepalive',
@@ -750,6 +751,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
 
         # movies
         'movie_output': False,
+        'movie_passthrough': bool(ui['movie_passthrough']),
         'movie_filename': ui['movie_file_name'],
         'movie_max_time': ui['max_movie_length'],
         '@preserve_movies': int(ui['preserve_movies']),
@@ -1124,6 +1126,7 @@ def motion_camera_dict_to_ui(data):
         'movie_file_name': data['movie_filename'],
         'max_movie_length': data['movie_max_time'],
         'preserve_movies': data['@preserve_movies'],
+        'movie_passthrough': data['movie_passthrough'],
 
         # motion detection
         'motion_detection': data['@motion_detection'],
@@ -1929,6 +1932,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('movie_filename', '%Y-%m-%d/%H-%M-%S')
     data.setdefault('movie_max_time', 0)
     data.setdefault('movie_output', False)
+    data.setdefault('movie_passthrough', False)
 
     if motionctl.has_h264_omx_support():
         data.setdefault('movie_codec', 'mp4:h264_omx')  # will use h264 codec

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -706,6 +706,7 @@ function initUI() {
     $('#moviesEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     $('#motionDetectionEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     $('#preserveMoviesSelect').change(updateConfigUI);
+    $('#moviePassthroughSwitch').change(updateConfigUI);
     $('#workingScheduleEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     
     $('#mondayEnabledSwitch').change(updateConfigUI);
@@ -1939,6 +1940,7 @@ function cameraUi2Dict() {
         'movie_file_name': $('#movieFileNameEntry').val(),
         'movie_quality': $('#movieQualitySlider').val(),
         'movie_format': $('#movieFormatSelect').val(),
+        'movie_passthrough': $('#moviePassthroughSwitch')[0].checked,
         'recording_mode': $('#recordingModeSelect').val(),
         'max_movie_length': $('#maxMovieLengthEntry').val(),
         'preserve_movies': $('#preserveMoviesSelect').val() >= 0 ? $('#preserveMoviesSelect').val() : $('#moviesLifetimeEntry').val(),
@@ -2302,6 +2304,7 @@ function dict2CameraUi(dict) {
     $('#movieFormatSelect').val(dict['movie_format']); markHideIfNull('movie_format', 'movieFormatSelect');
     $('#recordingModeSelect').val(dict['recording_mode']); markHideIfNull('recording_mode', 'recordingModeSelect');
     $('#maxMovieLengthEntry').val(dict['max_movie_length']); markHideIfNull('max_movie_length', 'maxMovieLengthEntry');
+    $('#moviePassthroughSwitch')[0].checked = dict['movie_passthrough'];
     $('#preserveMoviesSelect').val(dict['preserve_movies']);
     if ($('#preserveMoviesSelect').val() == null) {
         $('#preserveMoviesSelect').val('-1');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -749,6 +749,11 @@
                             <td><span class="help-mark" title="sets the name pattern for the movie files; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number, / = subfolder">?</span></td>
                         </tr>
                         <tr class="settings-item">
+                            <td class="settings-item-label"><span class="settings-item-label">Movie  passthrough</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled movies camera-config" id="moviePassthroughSwitch"></td>
+                            <td><span class="help-mark" title="Create movie files of the motion directly from the camera. This option should reduce CPU usage but does increase memory requirements. No image processing is performed so text overlays, privacy masks etc will not be on the resulting video.">?</span></td>
+                        </tr>
+                        <tr class="settings-item" depends="!moviePassthrough">
                             <td class="settings-item-label"><span class="settings-item-label">Movie Format</span></td>
                             <td class="settings-item-value">
                                 <select class="styled movies camera-config" id="movieFormatSelect">


### PR DESCRIPTION
https://motion-project.github.io/motion_config.html#movie_passthrough

 When using a RTSP, RTMP, mjpeg and some V4l2 cameras, create movie files of the motion with the packets obtained directly from the camera. 