### PR TITLE
allow multiple layout columns on mobile

### DIFF
--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -1377,16 +1377,6 @@ img.camera-progress {
         font-size: 16px !important;
         margin-left: auto !important;
     }
-
-    div.camera-frame {
-        width: 100% !important;
-    }
-    
-    #layoutColumnsRow {
-        /* layout columns are ignored on small screens,
-         * so hide the prefs row as well */
-        display: none !important;
-    }
 }
 
 @media all and (max-height: 320px) {


### PR DESCRIPTION
Having a single column view with multiple cams on mobile/tablet was quite restrictive, better to give user the choice?