### PR TITLE
Travis CI: Use flake8 on the Dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+language: python
+python:
+  - 2.7
+  # - 3.8
+
 notifications:
   email:
     recipients:
@@ -8,6 +13,10 @@ notifications:
 env:
   - TARGET=amd64 EXT=""
   - TARGET=armhf EXT=".armv7-armhf"
+
+before_script:
+   - pip install flake8
+   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 script:
   - docker info


### PR DESCRIPTION
Like #1589 but on the `dev` branch on legacy Python.