### PR TITLE
Added support for nvenc hardware encoding

### DIFF
--- a/motioneye/handlers.py
+++ b/motioneye/handlers.py
@@ -248,6 +248,10 @@ class MainHandler(BaseHandler):
                     admin_username=config.get_main().get('@admin_username'),
                     has_h264_omx_support=motionctl.has_h264_omx_support(),
                     has_h264_v4l2m2m_support=motionctl.has_h264_v4l2m2m_support(),
+                    has_h264_nvenc_support=motionctl.has_h264_nvenc_support(),
+                    has_hevc_nvenc_support=motionctl.has_hevc_nvenc_support(),
+                    has_h264_qsv_support=motionctl.has_h264_qsv_support(),
+                    has_hevc_qsv_support=motionctl.has_hevc_qsv_support(),
                     has_motion=bool(motionctl.find_motion()[0]),
                     mask_width=utils.MASK_WIDTH)
 

--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -377,6 +377,41 @@ def has_h264_v4l2m2m_support():
 
     return 'h264_v4l2m2m' in codecs.get('h264', {}).get('encoders', set())
 
+def has_h264_nvenc_support():
+    binary, version, codecs = mediafiles.find_ffmpeg()
+    if not binary:
+        return False
+
+    # TODO also check for motion codec parameter support
+
+    return 'h264_nvenc' in codecs.get('h264', {}).get('encoders', set())
+
+def has_hevc_nvenc_support():
+    binary, version, codecs = mediafiles.find_ffmpeg()
+    if not binary:
+        return False
+
+    # TODO also check for motion codec parameter support
+
+    return 'hevc_nvenc' in codecs.get('hevc', {}).get('encoders', set())
+
+def has_h264_qsv_support():
+    binary, version, codecs = mediafiles.find_ffmpeg()
+    if not binary:
+        return False
+
+    # TODO also check for motion codec parameter support
+
+    return 'h264_qsv' in codecs.get('h264', {}).get('encoders', set())
+
+def has_hevc_qsv_support():
+    binary, version, codecs = mediafiles.find_ffmpeg()
+    if not binary:
+        return False
+
+    # TODO also check for motion codec parameter support
+
+    return 'hevc_qsv' in codecs.get('hevc', {}).get('encoders', set())
 
 def resolution_is_valid(width, height):
     # width & height must be be modulo 8

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -763,6 +763,9 @@
                                     <option value="flv">Flash Video (.flv)</option>
                                     <option value="mov">QuickTime (.mov)</option>
                                     <option value="mp4">H.264 (.mp4)</option>
+                                    {% if has_h264_nvenc_support %}
+                                    <option value="mp4:h264_nvenc">H.264/NVENC (.mp4)</option>
+                                    {% endif %}
                                     {% if has_h264_omx_support %}
                                     <option value="mp4:h264_omx">H.264/OMX (.mp4)</option>
                                     {% endif %}
@@ -770,6 +773,9 @@
                                     <option value="mp4:h264_v4l2m2m">H.264/V4L2M2M (.mp4)</option>
                                     {% endif %}
                                     <option value="hevc">HEVC (.mp4)</option>
+                                    {% if has_hevc_nvenc_support %}
+                                    <option value="mp4:hevc_nvenc">HVEC/NVENC (.mp4)</option>
+                                    {% endif %}
                                     <option value="mkv">Matroska Video (.mkv)</option>
                                     {% if has_h264_omx_support %}
                                     <option value="mkv:h264_omx">Matroska Video/OMX (.mkv)</option>


### PR DESCRIPTION
Added support for nvenc hardware encoding as well as qsv. Disabled qsv user selection for now, as driver install and ffmpeg functions are an issue to compile and test. nvenc works fine though and decreases CPU usage exponentially. Implementation follows previously derived codec checking and interface display.