### PR TITLE
Insert py file to sys path first to avoid confusing second instance f…

### DIFF
--- a/motioneye/meyectl.py
+++ b/motioneye/meyectl.py
@@ -23,7 +23,7 @@ import pipes
 import sys
 
 # make sure motioneye is on python path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0,os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import settings
 


### PR DESCRIPTION
Ran into an issue when motioneye was installed with pip and also git cloned into a different directory. The service file was modified to use the git directory. The template and static files used kept defaulting to the python directory rather than the originally loaded service path. This was due to the sys.path being appended rather than inserted to the front of the path list.