### PR TITLE
Update main.js

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -18,7 +18,7 @@ var passwordHash = '';
 var basePath = null;
 var signatureRegExp = new RegExp('[^A-Za-z0-9/?_.=&{}\\[\\]":, -]', 'g');
 var deviceNameValidRegExp = new RegExp('^[A-Za-z0-9\-\_\+\ ]+$');
-var filenameValidRegExp = new RegExp('^([A-Za-z0-9 \(\)/._-]|%[YmdHMSqv])+$');
+var filenameValidRegExp = new RegExp('^([A-Za-z0-9 \(\)/._-]|%[CYmdHMSqv])+$');
 var dirnameValidRegExp = new RegExp('^[A-Za-z0-9 \(\)/._-]+$');
 var emailValidRegExp = new RegExp('^[A-Za-z0-9 _+.@^~<>,-]+$');
 var initialConfigFetched = false; /* used to workaround browser extensions that trigger stupid change events */


### PR DESCRIPTION
I specify 'text_event' in 'extra motion options' to create a filepaths for still images and movies based on events. This useful functionality appears to been removed recently: I get 'special characters are not allowed in file name' and cannot set the value.

filenameValidRegExp should allow Conversion Specifier '%C' so that images and movies can reference the value defined by 'text_event'.

Perhaps other Conversion Specifiers (https://motion-project.github.io/motion_config.html) should be allowed too, but I definitely need this one!
