### PR TITLE
Add link to release notes in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-**motionEye** is a web-based frontend for `motion <https://motion-project.github.io>`_. Check out the `wiki <https://github.com/ccrisan/motioneye/wiki>`_ for more details.
+**motionEye** is a web-based frontend for `motion <https://motion-project.github.io>`_. Check out the `wiki <https://github.com/ccrisan/motioneye/wiki>`_ for more details. Changelog is available on the `releases page <https://github.com/ccrisan/motioneye/releases>`_.
 
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg


### PR DESCRIPTION
Based on #1785 added a link to release notes to make it easier for people not familiar with Github (and with no interest in the "code" section) to find that information. Maybe the same link should be added to the Wiki, too, since every other bit of information is already there).