### PR TITLE
Fix docker build, move to Debian buster.

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM debian:buster-slim
 LABEL maintainer="Marcus Klein <himself@kleini.org>"
 
 ARG BUILD_DATE
@@ -14,35 +14,31 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 COPY . /tmp/motioneye
 
-RUN apt-get update && \
-    apt-get upgrade --yes && \
-    DEBIAN_FRONTEND="noninteractive" apt-get --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
-    curl \
-    ffmpeg \
-    libmicrohttpd12 \
-    libmysqlclient20 \
-    libpq5 \
-    lsb-release \
-    mosquitto-clients \
-    python-jinja2 \
-    python-pil \
-    python-pip \
-    python-pycurl \
-    python-setuptools \
-    python-tornado \
-    python-tz \
-    python-wheel \
-    tzdata \
-    v4l-utils && \
-    curl -L --output /tmp/motion.deb https://github.com/Motion-Project/motion/releases/download/release-4.2.2/cosmic_motion_4.2.2-1_amd64.deb && \
-    dpkg -i /tmp/motion.deb && \
-    rm /tmp/motion.deb && \
+RUN echo "deb http://snapshot.debian.org/archive/debian/20200630T024205Z sid main contrib non-free" >>/etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -t stable --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+      curl \
+      ffmpeg \
+      libmicrohttpd12 \
+      libpq5 \
+      lsb-release \
+      mosquitto-clients \
+      python-jinja2 \
+      python-pil \
+      python-pip \
+      python-pip-whl \
+      python-pycurl \
+      python-setuptools \
+      python-tornado \
+      python-tz \
+      python-wheel \
+      v4l-utils && \
     pip install /tmp/motioneye && \
     rm -rf /tmp/motioneye && \
-    apt-get purge --yes \
-    python-pip \
-    python-setuptools \
-    python-wheel && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -t sid --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
+      motion \
+      libmysqlclient20 && \
+    apt-get purge --yes python-setuptools python-wheel && \
     apt-get autoremove --yes && \
     apt-get --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
@@ -57,7 +53,7 @@ VOLUME /var/lib/motioneye
 
 ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
 
-CMD test -e /etc/motioneye/motioneye.conf || \    
+CMD test -e /etc/motioneye/motioneye.conf || \
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
     /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
 


### PR DESCRIPTION
- Moved to Debian buster as ubuntu 18.10 is no longer available in docker hub.
- Some packages need to come from sid (E.g. motion itself). In that
  case, make the build reproducible by fixing sid to a snapshot.

Fixes #1818 