### PR TITLE
Add support to run motionEye as a non-root user.

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -12,6 +12,10 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/ccrisan/motioneye.git"
 
+# By default, run as root.
+ARG RUN_UID=0
+ARG RUN_GID=0
+
 COPY . /tmp/motioneye
 
 RUN echo "deb http://snapshot.debian.org/archive/debian/20200630T024205Z sid main contrib non-free" >>/etc/apt/sources.list && \
@@ -33,28 +37,32 @@ RUN echo "deb http://snapshot.debian.org/archive/debian/20200630T024205Z sid mai
       python-tz \
       python-wheel \
       v4l-utils && \
-    pip install /tmp/motioneye && \
-    rm -rf /tmp/motioneye && \
     DEBIAN_FRONTEND="noninteractive" apt-get -t sid --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
       motion \
       libmysqlclient20 && \
+    # Change uid/gid of user/group motion to match our desired IDs.  This will
+    # make it easier to use execute motion as our desired user later.
+    sed -i -e "s/^\(motion:[^:]*\):[0-9]*:[0-9]*:\(.*\)/\1:${RUN_UID}:${RUN_GID}:\2/" /etc/passwd && \
+    sed -i -e "s/^\(motion:[^:]*\):[0-9]*:\(.*\)/\1:${RUN_GID}:\2/" /etc/group && \
+    pip install /tmp/motioneye && \
+    # Cleanup
+    rm -rf /tmp/motioneye && \
     apt-get purge --yes python-setuptools python-wheel && \
     apt-get autoremove --yes && \
     apt-get --yes clean && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
+ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
+
 # R/W needed for motioneye to update configurations
 VOLUME /etc/motioneye
-
-# PIDs
-VOLUME /var/run/motion
 
 # Video & images
 VOLUME /var/lib/motioneye
 
-ADD extra/motioneye.conf.sample /usr/share/motioneye/extra/
-
 CMD test -e /etc/motioneye/motioneye.conf || \
     cp /usr/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf ; \
-    /usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf
+    # We need to chown at startup time since volumes are mounted as root. This is fugly.
+    chown motion:motion /var/run /var/log /etc/motioneye /var/lib/motioneye /usr/share/motioneye/extra ; \
+    su -g motion motion -s /bin/bash -c "/usr/local/bin/meyectl startserver -c /etc/motioneye/motioneye.conf"
 
 EXPOSE 8765

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,0 +1,77 @@
+# Docker instructions
+
+## Running from the official images
+
+The easiest way to run motionEye under docker is to use the official images.
+The command below will run motionEye and preserve your configuration and videos
+across motionEye restarts.
+
+```bash
+docker pull ccrisan/motioneye:master-amd64
+docker run \
+  -rm \
+  -d \
+  -p 8765:8765 \
+  --hostname="motioneye" \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v /data/motioneye/config:/etc/motioneye \
+  -v /data/motioneye/videos:/var/lib/motioneye \
+  ccrisan/motioneye:master-amd64
+```
+
+This configuration maps motionEye configs into the `/data/motioneye/config`
+directory on the host. Videos will be saved under `/data/motioneye/videos`.
+Change the directories to suit your particular needs and make sure those
+directories exist on the host before you start the container.
+
+Some may prefer to use docker volumes instead of mapped directories on the
+host. You can easily accomplish this by using the commands below:
+
+```bash
+docker volume create motioneye-config
+docker volume create motioneye-videos
+docker pull ccrisan/motioneye:master-amd64
+docker run
+  -rm \
+  -d \
+  -p 8765:8765 \
+  --hostname="motioneye" =
+  -v /etc/localtime:/etc/localtime:ro \
+  --mount type=volume,source=motioneye-config,destination=/etc/motioneye \
+  --mount type=volume,source=motioneye-videos,destination=/var/lib/motioneye \
+  ccrisan/motioneye:master-amd64
+```
+
+Use `docker volume ls` to view existing volumes.
+
+## Building your own image
+
+It's also possible to build your own motionEye docker image. This allows the
+use of UIDs other than root for the `motion` and `meyectl` daemons (the default
+on official images). If you want to use a non-privileged user/group for
+motionEye, *please make sure that user/group exist on the host* before running
+the commands below.
+
+For the examples below, we assume user `motion` and group `motion` exist on the host server.
+
+```bash
+RUN_USER="motion"
+RUN_UID="id -u ${RUN_USER}"
+RUN_GID="id -g ${RUN_USER}"
+TIMESTAMP="$(date '+%Y%m%d-%H%M')"
+
+cd /tmp && \
+git clone https://github.com/ccrisan/motioneye.git && \
+cd motioneye && \
+docker build \
+  --build-arg="RUN_UID=${RUN_UID?}" \
+  --build-arg="RUN_GID=${RUN_GID?}" \
+  -t "${USER?}/motioneye:${TIMESTAMP}" \
+  --no-cache \
+  -f extra/Dockerfile .
+```
+
+This will create a local image called `your_username/motioneye:YYYYMMDD-HHMM`.
+You can run this image using the examples under "Running official images", but
+omitting the `docker pull` command and replacing
+`ccrisan/motioneye:master-amd64` with the name of the local image you just built.


### PR DESCRIPTION
- Added RUN_UID and RUN_GID args to Dockerfile. This allows the creation
  of an image that runs as a non-privileged user. If no args are
  specified at the container creation time, UID and GID will default
  to root/root, as before.
- Reordered commands in the Dockerfile a bit.
- Removed /var/run/motion as a PID, since we may want to run
  another instance of motion on a docker and this could prevent it.
- Added docker specific documentation.

Fixes: #1819 