### PR TITLE
Add basic validation to webhook URL to avoid crash in config parsing

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -21,6 +21,7 @@ var deviceNameValidRegExp = new RegExp('^[A-Za-z0-9\-\_\+\ ]+$');
 var filenameValidRegExp = new RegExp('^([A-Za-z0-9 \(\)/._-]|%[CYmdHMSqv])+$');
 var dirnameValidRegExp = new RegExp('^[A-Za-z0-9 \(\)/._-]+$');
 var emailValidRegExp = new RegExp('^[A-Za-z0-9 _+.@^~<>,-]+$');
+var webHookUrlValidRegExp = new RegExp('^[^;\']+$');
 var initialConfigFetched = false; /* used to workaround browser extensions that trigger stupid change events */
 var pageContainer = null;
 var overlayVisible = false;
@@ -636,6 +637,13 @@ function initUI() {
     makeCustomValidator($('#imageFileNameEntry, #movieFileNameEntry'), function (value) {
         if (!value.match(filenameValidRegExp)) {
             return "special characters are not allowed in file name";
+        }
+
+        return true;
+    }, '');
+    makeCustomValidator($('#webHookNotificationsUrlEntry'), function (value) {
+        if (!value.match(webHookUrlValidRegExp)) {
+            return "use of semicolon (;) or single quote (\') is not allowed in web hook URL";
         }
 
         return true;

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -1057,7 +1057,7 @@
                         <tr class="settings-item" required="true" depends="webHookNotificationsEnabled motionDetectionEnabled" strip="true">
                             <td class="settings-item-label"><span class="settings-item-label">Web Hook URL</span></td>
                             <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="webHookNotificationsUrlEntry" placeholder="e.g. http://example.com/notify/"></td>
-                            <td><span class="help-mark" title="a URL to be requested when motion is detected; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number">?</span></td>
+                            <td><span class="help-mark" title="a single URL to be requested when motion is detected; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="webHookNotificationsEnabled motionDetectionEnabled">
                             <td class="settings-item-label"><span class="settings-item-label">HTTP Method</span></td>


### PR DESCRIPTION
Fixes the issue mentioned in #1843: A semicolon in webhook URL will crash the config parsing. Also fixed the side effect of having a single quote in the URL (the part after that will disappear when config is saved the next time).