### PR TITLE
replace hardcoded Debian snapshot with latest

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -18,7 +18,7 @@ ARG RUN_GID=0
 
 COPY . /tmp/motioneye
 
-RUN echo "deb http://snapshot.debian.org/archive/debian/20200630T024205Z sid main contrib non-free" >>/etc/apt/sources.list && \
+RUN echo "deb http://snapshot.debian.org/archive/debian/$(date +%Y%m%d) sid main contrib non-free" >>/etc/apt/sources.list && \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -t stable --yes --option Dpkg::Options::="--force-confnew" --no-install-recommends install \
       curl \


### PR DESCRIPTION
I tried to build my own docker image and got the following error:

```
Reading package lists...
E: Release file for http://snapshot.debian.org/archive/debian/20200630T024205Z/dists/sid/InRelease is expired (invalid since 91d 3h 59min 33s). Updates for this repository will not be applied.
```

The proposed change aims to replace the hardcoded snapshot link with an actual snapshot valid on time of build and decrease the chance of such an issue in future