### PR TITLE
Update to uploadservices.py to reduce the Google Drive scope to drive…

### DIFF
--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -326,7 +326,7 @@ class GoogleBase:
 class GoogleDrive(UploadService, GoogleBase):
     NAME = 'gdrive'
 
-    SCOPE = 'https://www.googleapis.com/auth/drive'
+    SCOPE = 'https://www.googleapis.com/auth/drive.file'
     CHILDREN_URL = 'https://www.googleapis.com/drive/v2/files/%(parent_id)s/children?q=%(query)s'
     CHILDREN_QUERY = "'%(parent_id)s' in parents and title = '%(child_name)s' and trashed = false"
     UPLOAD_URL = 'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'


### PR DESCRIPTION
….file

At line 329, motionEye is requesting a Google Drive scope of "drive" which grants access to *all* of a user's files. This PR reduces the scope to "drive.file" which allows motionEye to create files on a user's Google Drive and to then only access/delete those files. This is the recommended best practice from Google, ie. to only request the minimum scope necessary for the application's needs. See https://developers.google.com/drive/api/v2/about-auth