### PR TITLE
docker compose override with reasonable defaults

### DIFF
--- a/extra/docker-compose.override.yml
+++ b/extra/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: "3.5"
+services:
+  motioneye:
+    restart: unless-stopped
+    image: ccrisan/motioneye:dev-amd64  # dev image
+    devices:
+      - "/dev/video0:/dev/video0"
+      - "/dev/video1:/dev/video1"
+    volumes:
+      - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Some critical additions: timezone sync via /etc/localtime volume mount, and device visibility via device option. Also using the restart option for service persistence and pointing to the dev image.