### PR TITLE
Create timelapse movies using specified codec instead of forcing avi

### DIFF
--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -365,9 +365,10 @@ class PictureHandler(BaseHandler):
 
                 pretty_filename = camera_config['camera_name'] + '_' + group
                 pretty_filename = re.sub('[^a-zA-Z0-9]', '_', pretty_filename)
-                pretty_filename += '.' + mediafiles.FFMPEG_EXT_MAPPING.get(camera_config['movie_codec'], 'avi')
+                filename_ext = mediafiles.FFMPEG_EXT_MAPPING.get(camera_config['movie_codec'], 'avi')
+                pretty_filename += '.' + filename_ext
 
-                self.set_header('Content-Type', 'video/x-msvideo')
+                self.set_header('Content-Type', mediafiles.MOVIE_EXT_TYPE_MAPPING.get(filename_ext, 'video/x-msvideo'))
                 self.set_header('Content-Disposition', 'attachment; filename=' + pretty_filename + ';')
                 return self.finish(data)
 

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -65,6 +65,10 @@ FFMPEG_FORMAT_MAPPING = {
     'mov': 'mov',
     'mp4': 'mp4',
     'mkv': 'matroska',
+    'mp4:h264_omx': 'mp4',
+    'mkv:h264_omx': 'matroska',
+    'mp4:h264_v4l2m2m': 'mp4',
+    'mkv:h264_v4l2m2m': 'matroska',
     'hevc': 'mp4'
 }
 
@@ -76,7 +80,20 @@ FFMPEG_EXT_MAPPING = {
     'mov': 'mov',
     'mp4': 'mp4',
     'mkv': 'mkv',
+    'mp4:h264_omx': 'mp4',
+    'mkv:h264_omx': 'mkv',
+    'mp4:h264_v4l2m2m': 'mp4',
+    'mkv:h264_v4l2m2m': 'mkv',
     'hevc': 'mp4'
+}
+
+MOVIE_EXT_TYPE_MAPPING = {
+    'avi': 'video/x-msvideo',
+    'mp4': 'video/mp4',
+    'mov': 'video/quicktime',
+    'swf': 'application/x-shockwave-flash',
+    'flv': 'video/x-flv',
+    'mkv': 'video/x-matroska'
 }
 
 # a cache of prepared files (whose preparing time is significant)
@@ -592,10 +609,12 @@ def make_timelapse_movie(camera_config, framerate, interval, group):
     global _timelapse_data
 
     target_dir = camera_config.get('target_dir')
-    codec = camera_config.get('movie_codec')
+    # save movie_codec as a different variable so it doesn't get lost in the CODEC_MAPPING
+    movie_codec = camera_config.get('movie_codec')
 
-    codec = FFMPEG_CODEC_MAPPING.get(codec, codec)
-    fmt = FFMPEG_FORMAT_MAPPING.get(codec, codec)
+    codec = FFMPEG_CODEC_MAPPING.get(movie_codec, movie_codec)
+    fmt = FFMPEG_FORMAT_MAPPING.get(movie_codec, movie_codec)
+    file_format = FFMPEG_EXT_MAPPING.get(movie_codec, movie_codec)
 
     # create a subprocess to retrieve media files
     def do_list_media(pipe):
@@ -625,7 +644,9 @@ def make_timelapse_movie(camera_config, framerate, interval, group):
     started = [datetime.datetime.now()]
     media_list = []
 
-    tmp_filename = os.path.join(settings.MEDIA_PATH, '.%s.avi' % int(time.time()))
+    # use correct extension for the movie_codec
+    tmp_filename = os.path.join(settings.MEDIA_PATH, '.%(name)s.%(ext)s')
+    tmp_filename = tmp_filename % { 'name': int(time.time()), 'ext': file_format }
 
     def read_media_list():
         while parent_pipe.poll():
@@ -694,9 +715,10 @@ def make_timelapse_movie(camera_config, framerate, interval, group):
     def make_movie(pictures):
         global _timelapse_process
 
+        # don't specify file format with -f, let ffmpeg work it out from the extension
         cmd = 'rm -f %(tmp_filename)s;'
         cmd += 'cat %(jpegs)s | ffmpeg -framerate %(framerate)s -f image2pipe -vcodec mjpeg -i - -vcodec %(codec)s ' \
-               '-format %(format)s -b:v %(bitrate)s -qscale:v 0.1 -f avi %(tmp_filename)s'
+               '-format %(format)s -b:v %(bitrate)s -qscale:v 0.1 %(tmp_filename)s'
 
         bitrate = 9999999
 


### PR DESCRIPTION
Currently the timelapse movies created will use the movie_codec from the camera config for the file extension, but ffmpeg will still use the -f avi option to create an avi file and the content-type of the file will be avi.
This change will tell ffmpeg to create a timelapse using the codec specified in the camera configuration and set  the content-type accordingly.