### PR TITLE
convert bytes into a string (subprocess.check_output return value)

### DIFF
--- a/motioneye/mmalctl.py
+++ b/motioneye/mmalctl.py
@@ -34,7 +34,7 @@ def list_devices():
         return []
 
     try:
-        support = subprocess.check_output([binary, 'get_camera']).strip()
+        support = subprocess.check_output([binary, 'get_camera']).strip().decode('utf8')
 
     except subprocess.CalledProcessError:  # not found
         return []


### PR DESCRIPTION
subprocess.check_output() in Python 3 returns bytes instead of a string, and therefore the return value needs to be converted into a string in order to call split() on it in L42. Not doing this causes a type mismatch error:
```
  File "/home/viridian/src/motioneye-fork/motioneye/mmalctl.py", line 42, in <genexpr>
    d = dict(p.split('=', 1) for p in support.split())
TypeError: a bytes-like object is required, not 'str'
```