### PR TITLE
#2237: Modify default port from 808x

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1933,7 +1933,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@clean_cloud_enabled', False)
 
     data.setdefault('stream_localhost', False)
-    data.setdefault('stream_port', 8080 + camera_id)
+    data.setdefault('stream_port', 8180 + camera_id)
     data.setdefault('stream_maxrate', 5)
     data.setdefault('stream_quality', 85)
     data.setdefault('stream_motion', False)


### PR DESCRIPTION
Modify default port from 808x to 818x to avoid overlap when users installing directly onto a machine, without docker.

Full explanation can be found in issue #2237 