### PR TITLE
sendmail: Use actual TLS connection if enabled

### DIFF
--- a/motioneye/sendmail.py
+++ b/motioneye/sendmail.py
@@ -41,9 +41,10 @@ subjects = {'motion_start': 'motionEye: motion detected by "%(camera)s"'}
 
 
 def send_mail(server, port, account, password, tls, _from, to, subject, message, files):
-    conn = smtplib.SMTP(server, port, timeout=settings.SMTP_TIMEOUT)
     if tls:
-        conn.starttls()
+        conn = smtplib.SMTP_SSL(server, port, timeout=settings.SMTP_TIMEOUT)
+    else:
+        conn = smtplib.SMTP(server, port, timeout=settings.SMTP_TIMEOUT)
 
     if account and password:
         conn.login(account, password)


### PR DESCRIPTION
Currently, enabling TLS actually enables STARTTLS while the initial connection is still done as plain SMTP. This is counter-intuitive, since TLS, the way providers use it in their docs, usually means a TLS-encrypted connection right from the start. STARTTLS is usually named as such, and handled on another port, or enforced automatically on plain connections.

This commit changes the behaviour to use an initial TLS-encrypted SMTP connection if this setting is enabled. While most providers allow and redirect all connection types on all ports, for some this may be a breaking change, i.e. it might be required to change the port e.g. from 587 to 465.