### PR TITLE
Fix #3073 - Remote motionEye Error

### DIFF
--- a/motioneye/remote.py
+++ b/motioneye/remote.py
@@ -76,19 +76,23 @@ def _make_request(
 
 
 async def _send_request(request: HTTPRequest) -> HTTPResponse:
-    response = await AsyncHTTPClient().fetch(request, raise_error=False)
+    try:
+        # The raise_error=False argument only affects the HTTPError raised when a non-200 response
+        # code is used, instead of suppressing all errors.
+        response = await AsyncHTTPClient().fetch(request, raise_error=False)
 
-    if response.code != 200:
-        try:
+        if response.code != 200:
+
             decoded = json.loads(response.body)
+
             if decoded['error'] == 'unauthorized':
                 response.error = Exception('Authentication Error')
-
             elif decoded['error']:
                 response.error = Exception(decoded['error'])
-
-        except Exception as e:
-            logging.error(f"_send_request: {e}")
+    except Exception as e:
+        logging.error(f"_send_request: {e}")
+        response = HTTPResponse(request, 500)
+        response.error = e
 
     return response
 

--- a/motioneye/remote.py
+++ b/motioneye/remote.py
@@ -84,14 +84,14 @@ async def _send_request(request: HTTPRequest) -> HTTPResponse:
         if response.code != 200:
 
             decoded = json.loads(response.body)
-
             if decoded['error'] == 'unauthorized':
                 response.error = Exception('Authentication Error')
+
             elif decoded['error']:
                 response.error = Exception(decoded['error'])
     except Exception as e:
         logging.error(f"_send_request: {e}")
-        response = HTTPResponse(request, 500)
+        response = HTTPResponse(request, 599)
         response.error = e
 
     return response


### PR DESCRIPTION
If a remote motionEye is unavailable an exception was not handled.. this was due to the entirely reasonable expectation `raise_error=False` would not raise an error. This is however not the case as documented in the [tornado.httpclient](https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient.fetch) documentation:

```
The raise_error=False argument only affects the HTTPError raised when a non-200 response code is used, instead of suppressing all errors.
```

Not entirely sure the other error 2 paths work either (i.e. `response.error` appears to expect an exception not a string).. but this commit fixes more than we started with and will fix more than it breaks 😄.