### PR TITLE
Set resolution factor to 1 when a mask is created

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -985,8 +985,15 @@ function initUI() {
     $('div#networkShareTestButton').on('click', doTestNetworkShare);
 
     /* mask editor buttons */
-    $('div#motionMaskEditButton, div#privacyMaskEditButton').on('click', function (event) {
+    $('div#motionMaskEditButton, div#privacyMaskEditButton').on('click', async function (event) {
         var cameraId = $('#cameraSelect').val();
+
+        if (resolutionFactor !== 1) {
+            resolutionFactor = 1; //set the resolution dimmer slider to 100% for correct measurement
+
+            await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
+        }
+
         var img = getCameraFrame(cameraId).find('img.camera')[0];
         if (!img._naturalWidth || !img._naturalHeight) {
             return runAlertDialog(i18n.gettext("Ne eblas redakti la maskon sen valida kameraa bildo!"));


### PR DESCRIPTION
When the resolution dimmer slider was used (and not set to 100), and a motion or privacy mask was created/changed, the measurement of the width & height went wrong. Because the number of pixels in the image was less.
Example: When the resolution dimmer slider was set to 80 on a camera with a resolution of 1024x768, it measured 819x614.
The 819x614 was converted to the correct resolution when creating the mask file:
DEBUG: building editable motion mask for camera with id 1 (819x614)
DEBUG: editable mask needs resizing from 819x614 to 1024x768
But this caused the mask to change, probably due to the remainder that is or is not present and due to the resizing itself.

This PR makes sure that the resolutionfactor (controlled by the resolution dimmer slider) is always equal to 1 when creating a mask. I had to add a 1 second delay so that this could be processed before the resolution is measured with 'getCameraFrame'. I hope this approach is acceptable.

Issue: #2755