### PR TITLE
docker: disable binfmt image and layers cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   docker:
@@ -15,14 +14,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
+      contents: read
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Docker meta
+      - uses: docker/metadata-action@v5
         id: meta
-        uses: docker/metadata-action@v5
         with:
           images: | # add potential Docker Hub image
             ghcr.io/${{ github.repository_owner }}/motioneye
@@ -33,16 +30,10 @@ jobs:
             type=semver,pattern={{major}}
 
       - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
         with:
-          path: |
-            ${{ runner.temp }}/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          cache-image: false
+
+      - uses: docker/setup-buildx-action@v3
 
       #- name: Login to Docker Hub
       #  uses: docker/login-action@v3
@@ -59,22 +50,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
         with:
-          context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/riscv64
           push: ${{ github.event_name == 'push' && github.repository == 'motioneye-project/motioneye' && steps.meta.outputs.tags != null }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          #build-args: |
-          #  KEY1=Value1
-          #  KEY2=Value2
-          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf ${{ runner.temp }}/.buildx-cache
-          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache


### PR DESCRIPTION
The binfmt cache in fact slows down the workflow. The Docker image is pulled in any case, and the cache additionally. Both are compared and the cache used if both match, or if the pull fails. So it is not a cache with the typical purpose to speed things up, reduce traffic or such, but a fallback, in case there are network issues, locally or at the Docker registry.

The Docker layer cache is very inefficiently used the way our Dockerfile is written. Due to the early COPY of our whole repository, it is always invalidated right there, as there is always a change in any file, of course. For this to work efficiently, we would need to COPY regularly changing repository content as late as possible into the image, and install all dependencies first. A cache layer is not invalidated at RUN commands, as long as the commands themselves do not change in the Docker file. But they are invalidated if after an ADD or COPY step the image content has changed. This however also means that, when installing dependencies first, the resulting layers will be used from cache forever, as long as it is available, and until steps in the Dockerfile until that point change. Whether we want APT packages and Python dependencies frozen in our Docker images for a potentially long time, only to potentially save some minutes of build time, is a serious question. If we had some lock files to COPY in, to handle vulnerabilities via dependabot or similar, for cache invalidation in case of fixed vulnerabilities via raised dependency version, that can work. But currently it would be a security issue. For APT packages there are additional issues, as long as Debian Trixie is in testing. In any case, currently we just copy back and forth 1 GiB or data for no reason. The Debian slim images are less than 30 MiB in size, so downloading them (once for each architecture) is faster than restoring and saving the huge cache.

Furthermore, buildx in the meantime supports a Docker registry cache, using just the existing image from the registry as cache, optionally a dedicated one in the registry, or it can utilize the GitHub cache API directly. No need to manually manage a cache directory.

Also, permissions are granted at job level, and the checkout is skipped: When not defining "context", the build-push-action does this internally.