### PR TITLE
Support S3 Server Side Encryption with custom key

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -513,6 +513,7 @@ def get_camera(camera_id, as_lines=False):
             '@upload_access_key',
             '@upload_secret_key',
             '@upload_bucket',
+            '@upload_sse_c_key',
             'camera_name',
         ],
     )
@@ -912,6 +913,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         '@upload_access_key': ui['upload_access_key'],
         '@upload_secret_key': ui['upload_secret_key'],
         '@upload_bucket': ui['upload_bucket'],
+        '@upload_sse_c_key': ui['upload_sse_c_key'],
         '@clean_cloud_enabled': ui['clean_cloud_enabled'],
         # text overlay
         'text_left': '',
@@ -1427,6 +1429,7 @@ def motion_camera_dict_to_ui(data):
         'upload_access_key': data['@upload_access_key'],
         'upload_secret_key': data['@upload_secret_key'],
         'upload_bucket': data['@upload_bucket'],
+        'upload_sse_c_key': data['@upload_sse_c_key'],
         'clean_cloud_enabled': data['@clean_cloud_enabled'],
         'web_hook_storage_enabled': False,
         'command_storage_enabled': False,
@@ -2303,6 +2306,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_access_key', '')
     data.setdefault('@upload_secret_key', '')
     data.setdefault('@upload_bucket', '')
+    data.setdefault('@upload_sse_c_key', '')
     data.setdefault('@clean_cloud_enabled', False)
 
     data.setdefault('stream_localhost', False)

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1983,6 +1983,7 @@ function cameraUi2Dict() {
         'upload_access_key': $('#uploadAccessKeyEntry').val(),
         'upload_secret_key': $('#uploadSecretKeyEntry').val(),
         'upload_bucket': $('#uploadBucketEntry').val(),
+        'upload_sse_c_key': $('#uploadSseCKeyEntry').val(),
         'clean_cloud_enabled': $('#cleanCloudEnabledSwitch')[0].checked,
         'web_hook_storage_enabled': $('#webHookStorageEnabledSwitch')[0].checked,
         'web_hook_storage_url': $('#webHookStorageUrlEntry').val(),
@@ -2320,6 +2321,7 @@ function dict2CameraUi(dict) {
     $('#uploadAccessKeyEntry').val(dict['upload_access_key']); markHideIfNull('upload_access_key', 'uploadAccessKeyEntry');
     $('#uploadSecretKeyEntry').val(dict['upload_secret_key']); markHideIfNull('upload_secret_key', 'uploadSecretKeyEntry');
     $('#uploadBucketEntry').val(dict['upload_bucket']); markHideIfNull('upload_bucket', 'uploadBucketEntry');
+    $('#uploadSseCKeyEntry').val(dict['upload_sse_c_key']); markHideIfNull('upload_sse_c_key', 'uploadSseCKeyEntry');
     $('#cleanCloudEnabledSwitch')[0].checked = dict['clean_cloud_enabled']; markHideIfNull('clean_cloud_enabled', 'cleanCloudEnabledSwitch');
 
     $('#webHookStorageEnabledSwitch')[0].checked = dict['web_hook_storage_enabled']; markHideIfNull('web_hook_storage_enabled', 'webHookStorageEnabledSwitch');
@@ -3061,7 +3063,8 @@ function doTestUpload() {
         endpoint_url: $('#uploadEndpointUrlEntry').val(),
         access_key: $('#uploadAccessKeyEntry').val(),
         secret_key: $('#uploadSecretKeyEntry').val(),
-        bucket: $('#uploadBucketEntry').val()
+        bucket: $('#uploadBucketEntry').val(),
+        sse_c_key: $('#uploadSseCKeyEntry').val()
     };
 
     var cameraId = $('#cameraSelect').val();

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -558,8 +558,8 @@
                         </tr>
                         <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Encryption key") }}</span></td>
-                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadSseCKeyEntry"></td>
-                            <td><span class="help-mark" title="{{ _("Add encryption key if you want use server side encryption (SSE-C). The key must be a base64 encoded string with a length of 32 bytes. You can generate a key using the following command: openssl rand 32 | base64") }}">?</span></td>
+                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadSseCKeyEntry" placeholder="{{ _("optional base64-encoded SSE-C encryption key") }}"></td>
+                            <td><span class="help-mark" title="{{ _("Add an encryption key if you want to use server side encryption (SSE-C). The key must be a base64-encoded string with a length of 32 bytes. This key will be needed by every client to access the encrypted files. You can generate a key using the following command: openssl rand 32 | base64") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="uploadEnabled">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -556,6 +556,11 @@
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="uploadBucketEntry"></td>
                             <td><span class="help-mark" title="{{ _("la nomo S3-sitelo por la alŝuta servo (kutime bezonata nur dum agordo)") }}">?</span></td>
                         </tr>
+                        <tr class="settings-item" depends="uploadEnabled uploadService=(s3)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Encryption key") }}</span></td>
+                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled storage camera-config" id="uploadSseCKeyEntry"></td>
+                            <td><span class="help-mark" title="{{ _("Add encryption key if you want use server side encryption (SSE-C). The key must be a base64 encoded string with a length of 32 bytes. You can generate a key using the following command: openssl rand 32 | base64") }}">?</span></td>
+                        </tr>
                         <tr class="settings-item" depends="uploadEnabled">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
                             <td class="settings-item-value"><div class="button normal-button test-button" id="uploadTestButton">{{ _("Testi la servon") }}</div></td>

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -1211,7 +1211,7 @@ class S3(UploadService):
             self._secret_key = data['secret_key']
         if data.get('bucket') is not None:
             self._bucket = data['bucket']
-        if data.get('sse_c_key'):
+        if data.get('sse_c_key') is not None:
             self._sse_c_key = data['sse_c_key']
 
     def upload_file(self, target_dir, filename, camera_name):

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -23,7 +23,8 @@ import mimetypes
 import os
 import os.path
 import time
-from base64 import b64encode
+from base64 import b64encode, b64decode
+from hashlib import md5
 from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
 from urllib.request import Request
@@ -1189,6 +1190,7 @@ class S3(UploadService):
         self._access_key = None
         self._secret_key = None
         self._bucket = None
+        self._sse_c_key = None
         UploadService.__init__(self, camera_id)
 
     def dump(self):
@@ -1197,6 +1199,7 @@ class S3(UploadService):
             'access_key': self._access_key,
             'secret_key': self._secret_key,
             'bucket': self._bucket,
+            'sse_c_key': self._sse_c_key,
         }
 
     def load(self, data):
@@ -1208,6 +1211,8 @@ class S3(UploadService):
             self._secret_key = data['secret_key']
         if data.get('bucket') is not None:
             self._bucket = data['bucket']
+        if data.get('sse_c_key'):
+            self._sse_c_key = data['sse_c_key']
 
     def upload_file(self, target_dir, filename, camera_name):
         # Create an S3 client
@@ -1226,12 +1231,22 @@ class S3(UploadService):
         else:
             rel_filename = os.path.basename(filename)
 
+        if self._sse_c_key:
+            sse_key_md5 = b64encode(md5(b64decode(self._sse_c_key)).digest()).decode("utf-8")
+            extra_args = {
+                "SSECustomerAlgorithm": "AES256",
+                "SSECustomerKey": self._sse_c_key,
+                "SSECustomerKeyMD5": sse_key_md5,
+            }
+        else:
+            extra_args = None
+
         # Uploads the given file using a managed uploader, which will split up
         # large files automatically and upload parts in parallel.
         self.debug(
             f'uploading file "{filename}" to S3 bucket "{self._bucket}" path "{rel_filename}"'
         )
-        s3.upload_file(filename, self._bucket, rel_filename)
+        s3.upload_file(filename, self._bucket, rel_filename, ExtraArgs=extra_args)
 
     def test_access(self):
         try:

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -23,7 +23,7 @@ import mimetypes
 import os
 import os.path
 import time
-from base64 import b64encode, b64decode
+from base64 import b64decode, b64encode
 from hashlib import md5
 from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
@@ -1232,11 +1232,13 @@ class S3(UploadService):
             rel_filename = os.path.basename(filename)
 
         if self._sse_c_key:
-            sse_key_md5 = b64encode(md5(b64decode(self._sse_c_key)).digest()).decode("utf-8")
+            sse_key_md5 = b64encode(
+                md5(b64decode(self._sse_c_key)).digest()  # nosec B324
+            ).decode()
             extra_args = {
-                "SSECustomerAlgorithm": "AES256",
-                "SSECustomerKey": self._sse_c_key,
-                "SSECustomerKeyMD5": sse_key_md5,
+                'SSECustomerAlgorithm': 'AES256',
+                'SSECustomerKey': self._sse_c_key,
+                'SSECustomerKeyMD5': sse_key_md5,
             }
         else:
             extra_args = None


### PR DESCRIPTION
Add a supports of Server Side Encryption known as [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html) for compatible S3 bucket provider.

The encryption is performed on the S3 server with the provided key. The key is not stored on the S3 server. To download encrypted file, you must therefore provide the same key.

The encryption key must be a base64 encoded string with a length of 32 bytes. You can generate one as following:

`openssl rand 32 | base64`