### PR TITLE
Add admin-only camera access control

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -885,6 +885,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
             deviceNameValidRegExp, ui['name'], 'camera_name', deviceNameFailMessage
         ),
         '@enabled': ui['enabled'],
+        '@admin_only': ui.get('admin_only', False),
         'auto_brightness': ui['auto_brightness'],
         'framerate': int(ui['framerate']),
         'rotate': int(ui['rotation']),
@@ -1393,6 +1394,7 @@ def motion_camera_dict_to_ui(data):
         'name': data['camera_name'],
         'enabled': data['@enabled'],
         'id': data['@id'],
+        'admin_only': data.get('@admin_only', False),
         'auto_brightness': data['auto_brightness'],
         'framerate': int(data['framerate']),
         'rotation': int(data['rotate']),
@@ -1901,6 +1903,7 @@ def simple_mjpeg_camera_ui_to_dict(ui, prev_config=None):
         # device
         'camera_name': ui['name'],
         '@enabled': ui['enabled'],
+        '@admin_only': ui.get('admin_only', False),
     }
 
     # additional configs
@@ -1922,6 +1925,7 @@ def simple_mjpeg_camera_dict_to_ui(data):
         'id': data['@id'],
         'proto': 'mjpeg',
         'url': data['@url'],
+        'admin_only': data.get('@admin_only', False),
     }
 
     # additional configs
@@ -2262,6 +2266,7 @@ def _set_default_motion(data):
 def _set_default_motion_camera(camera_id, data):
     data.setdefault('camera_name', 'Camera' + str(camera_id))
     data.setdefault('@id', camera_id)
+    data.setdefault('@admin_only', False)
 
     if utils.is_v4l2_camera(data):
         data.setdefault('videodevice', '/dev/video0')
@@ -2377,6 +2382,7 @@ def _set_default_motion_camera(camera_id, data):
 def _set_default_simple_mjpeg_camera(camera_id, data):
     data.setdefault('camera_name', 'Camera' + str(camera_id))
     data.setdefault('@id', camera_id)
+    data.setdefault('@admin_only', False)
 
 
 def get_additional_structure(camera, separators=False):

--- a/motioneye/handlers/action.py
+++ b/motioneye/handlers/action.py
@@ -37,7 +37,11 @@ class ActionHandler(BaseHandler):
 
         local_config = config.get_camera(camera_id)
         # block access to admin-only cameras for non-admin users
-        if local_config and local_config.get('@admin_only') and self.current_user != 'admin':
+        if (
+            local_config
+            and local_config.get('@admin_only')
+            and self.current_user != 'admin'
+        ):
             raise HTTPError(403, 'access denied')
         if utils.is_remote_camera(local_config):
             resp = await remote.exec_action(local_config, action)

--- a/motioneye/handlers/action.py
+++ b/motioneye/handlers/action.py
@@ -42,7 +42,10 @@ class ActionHandler(BaseHandler):
             and local_config.get('@admin_only')
             and self.current_user != 'admin'
         ):
-            raise HTTPError(403, 'access denied')
+            raise HTTPError(
+                403,
+                f'access denied to admin-only camera "{camera_id}" for action "{action}"',
+            )
         if utils.is_remote_camera(local_config):
             resp = await remote.exec_action(local_config, action)
             if resp.error:

--- a/motioneye/handlers/action.py
+++ b/motioneye/handlers/action.py
@@ -36,6 +36,9 @@ class ActionHandler(BaseHandler):
             raise HTTPError(404, 'no such camera')
 
         local_config = config.get_camera(camera_id)
+        # block access to admin-only cameras for non-admin users
+        if local_config and local_config.get('@admin_only') and self.current_user != 'admin':
+            raise HTTPError(403, 'access denied')
         if utils.is_remote_camera(local_config):
             resp = await remote.exec_action(local_config, action)
             if resp.error:

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -394,6 +394,19 @@ class ConfigHandler(BaseHandler):
         else:
             resp.remote_ui_config['id'] = camera_id
 
+            # sync admin_only flag locally to match the remote state
+            local_config.setdefault('@admin_only', False)
+            admin_only = bool(resp.remote_ui_config.get('admin_only', False))
+
+            if local_config.get('@admin_only') != admin_only:
+                local_config['@admin_only'] = admin_only
+                config.set_camera(camera_id, local_config)
+
+            # do not add this camera to the list if admin-only, but reduce the async counter so listing can finish
+            if admin_only and self.current_user != 'admin':
+                length[0] -= 1
+                return self.check_finished(cameras, length)
+
             if not resp.remote_ui_config['enabled'] and local_config['@enabled']:
                 # if a remote camera is disabled, make sure it's disabled locally as well
                 local_config['@enabled'] = False
@@ -490,6 +503,13 @@ class ConfigHandler(BaseHandler):
                 local_config = config.get_camera(camera_id)
                 if local_config is None:
                     continue
+                # hide admin-only cameras from non-admin users (local cameras only; remote handled after sync)
+                if (
+                    local_config.get('@admin_only')
+                    and self.current_user != 'admin'
+                    and not utils.is_remote_camera(local_config)
+                ):
+                    continue
 
                 if utils.is_local_motion_camera(local_config):
                     ui_config = config.motion_camera_dict_to_ui(local_config)
@@ -501,6 +521,7 @@ class ConfigHandler(BaseHandler):
                     if (
                         local_config.get('@enabled')
                         or self.get_argument('force', None) == 'true'
+                        or local_config.get('@admin_only')  # fetch remote config only while admin_only is true, to allow the flag to be cleared
                     ):
                         resp = await remote.get_config(local_config)
                         if self._handle_get_config_response(

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -521,7 +521,9 @@ class ConfigHandler(BaseHandler):
                     if (
                         local_config.get('@enabled')
                         or self.get_argument('force', None) == 'true'
-                        or local_config.get('@admin_only')  # fetch remote config only while admin_only is true, to allow the flag to be cleared
+                        or local_config.get(
+                            '@admin_only'
+                        )  # fetch remote config only while admin_only is true, to allow the flag to be cleared
                     ):
                         resp = await remote.get_config(local_config)
                         if self._handle_get_config_response(

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -394,23 +394,27 @@ class ConfigHandler(BaseHandler):
         else:
             resp.remote_ui_config['id'] = camera_id
 
+            needs_apply_config = False
+
             # sync admin_only flag locally to match the remote state
             local_config.setdefault('@admin_only', False)
             admin_only = bool(resp.remote_ui_config.get('admin_only', False))
 
             if local_config.get('@admin_only') != admin_only:
                 local_config['@admin_only'] = admin_only
-                config.set_camera(camera_id, local_config)
+                needs_apply_config = True
 
             # do not add this camera to the list if admin-only, but reduce the async counter so listing can finish
             if admin_only and self.current_user != 'admin':
+                if needs_apply_config:
+                    config.set_camera(camera_id, local_config)
                 length[0] -= 1
                 return self.check_finished(cameras, length)
 
             if not resp.remote_ui_config['enabled'] and local_config['@enabled']:
                 # if a remote camera is disabled, make sure it's disabled locally as well
                 local_config['@enabled'] = False
-                config.set_camera(camera_id, local_config)
+                needs_apply_config = True
 
             elif resp.remote_ui_config['enabled'] and not local_config['@enabled']:
                 # if a remote camera is locally disabled, make sure the remote config says the same thing
@@ -420,6 +424,9 @@ class ConfigHandler(BaseHandler):
                 resp.remote_ui_config[key.replace('@', '')] = value
 
             cameras.append(resp.remote_ui_config)
+
+            if needs_apply_config:
+                config.set_camera(camera_id, local_config)
 
         return self.check_finished(cameras, length)
 

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -164,6 +164,8 @@ class ConfigHandler(BaseHandler):
             elif utils.is_remote_camera(local_config):
                 # update the camera locally
                 local_config['@enabled'] = ui_config['enabled']
+                if ui_config.get('admin_only') is not None:
+                    local_config['@admin_only'] = bool(ui_config.get('admin_only'))
                 config.set_camera(camera_id, local_config)
 
                 if 'name' in ui_config:
@@ -172,6 +174,9 @@ class ConfigHandler(BaseHandler):
                         return on_finish(e, False)
 
                     ui_config['enabled'] = True  # never disable the camera remotely
+                    ui_config.pop(
+                        'admin_only', None
+                    )  # local-only setting do not send to remote
                     result = await remote.set_config(local_config, ui_config)
                     return on_finish(result, False)
 
@@ -394,27 +399,19 @@ class ConfigHandler(BaseHandler):
         else:
             resp.remote_ui_config['id'] = camera_id
 
-            needs_apply_config = False
-
-            # sync admin_only flag locally to match the remote state
+            # admin_only is a local-only flag and is never synced from the remote
             local_config.setdefault('@admin_only', False)
-            admin_only = bool(resp.remote_ui_config.get('admin_only', False))
-
-            if local_config.get('@admin_only') != admin_only:
-                local_config['@admin_only'] = admin_only
-                needs_apply_config = True
+            admin_only = bool(local_config.get('@admin_only', False))
 
             # do not add this camera to the list if admin-only, but reduce the async counter so listing can finish
             if admin_only and self.current_user != 'admin':
-                if needs_apply_config:
-                    config.set_camera(camera_id, local_config)
                 length[0] -= 1
                 return self.check_finished(cameras, length)
 
             if not resp.remote_ui_config['enabled'] and local_config['@enabled']:
                 # if a remote camera is disabled, make sure it's disabled locally as well
                 local_config['@enabled'] = False
-                needs_apply_config = True
+                config.set_camera(camera_id, local_config)
 
             elif resp.remote_ui_config['enabled'] and not local_config['@enabled']:
                 # if a remote camera is locally disabled, make sure the remote config says the same thing
@@ -424,9 +421,6 @@ class ConfigHandler(BaseHandler):
                 resp.remote_ui_config[key.replace('@', '')] = value
 
             cameras.append(resp.remote_ui_config)
-
-            if needs_apply_config:
-                config.set_camera(camera_id, local_config)
 
         return self.check_finished(cameras, length)
 
@@ -528,9 +522,6 @@ class ConfigHandler(BaseHandler):
                     if (
                         local_config.get('@enabled')
                         or self.get_argument('force', None) == 'true'
-                        or local_config.get(
-                            '@admin_only'
-                        )  # fetch remote config only while admin_only is true, to allow the flag to be cleared
                     ):
                         resp = await remote.get_config(local_config)
                         if self._handle_get_config_response(

--- a/motioneye/handlers/movie.py
+++ b/motioneye/handlers/movie.py
@@ -39,7 +39,10 @@ class MovieHandler(BaseHandler):
                 and camera_config.get('@admin_only')
                 and self.current_user != 'admin'
             ):
-                raise HTTPError(403, 'access denied')
+                raise HTTPError(
+                    403,
+                    f'access denied to admin-only camera "{camera_id}" for operation "{op}"',
+                )
 
         if op == 'list':
             await self.list(camera_id)

--- a/motioneye/handlers/movie.py
+++ b/motioneye/handlers/movie.py
@@ -34,7 +34,11 @@ class MovieHandler(BaseHandler):
                 raise HTTPError(404, 'no such camera')
             # block access to admin-only cameras for non-admin users
             camera_config = config.get_camera(camera_id)
-            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+            if (
+                camera_config
+                and camera_config.get('@admin_only')
+                and self.current_user != 'admin'
+            ):
                 raise HTTPError(403, 'access denied')
 
         if op == 'list':

--- a/motioneye/handlers/movie.py
+++ b/motioneye/handlers/movie.py
@@ -32,6 +32,10 @@ class MovieHandler(BaseHandler):
             camera_id = int(camera_id)
             if camera_id not in config.get_camera_ids():
                 raise HTTPError(404, 'no such camera')
+            # block access to admin-only cameras for non-admin users
+            camera_config = config.get_camera(camera_id)
+            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+                raise HTTPError(403, 'access denied')
 
         if op == 'list':
             await self.list(camera_id)

--- a/motioneye/handlers/movie_playback.py
+++ b/motioneye/handlers/movie_playback.py
@@ -51,7 +51,11 @@ class MoviePlaybackHandler(StaticFileHandler, BaseHandler):
 
         camera_config = config.get_camera(camera_id)
         # block access to admin-only cameras for non-admin users
-        if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+        if (
+            camera_config
+            and camera_config.get('@admin_only')
+            and self.current_user != 'admin'
+        ):
             raise HTTPError(403, 'access denied')
 
         if utils.is_local_motion_camera(camera_config):

--- a/motioneye/handlers/movie_playback.py
+++ b/motioneye/handlers/movie_playback.py
@@ -56,7 +56,10 @@ class MoviePlaybackHandler(StaticFileHandler, BaseHandler):
             and camera_config.get('@admin_only')
             and self.current_user != 'admin'
         ):
-            raise HTTPError(403, 'access denied')
+            raise HTTPError(
+                403,
+                f'access denied to admin-only camera "{camera_id}" for movie download "{filename}"',
+            )
 
         if utils.is_local_motion_camera(camera_config):
             filename = mediafiles.get_media_path(camera_config, filename, 'movie')

--- a/motioneye/handlers/movie_playback.py
+++ b/motioneye/handlers/movie_playback.py
@@ -50,6 +50,9 @@ class MoviePlaybackHandler(StaticFileHandler, BaseHandler):
                 raise HTTPError(404, 'no such camera')
 
         camera_config = config.get_camera(camera_id)
+        # block access to admin-only cameras for non-admin users
+        if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+            raise HTTPError(403, 'access denied')
 
         if utils.is_local_motion_camera(camera_config):
             filename = mediafiles.get_media_path(camera_config, filename, 'movie')

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -49,7 +49,11 @@ class PictureHandler(BaseHandler):
                 raise HTTPError(404, 'no such camera')
             # block access to admin-only cameras for non-admin users
             camera_config = config.get_camera(camera_id)
-            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+            if (
+                camera_config
+                and camera_config.get('@admin_only')
+                and self.current_user != 'admin'
+            ):
                 raise HTTPError(403, 'access denied')
 
         if op == 'current':
@@ -86,7 +90,11 @@ class PictureHandler(BaseHandler):
                 raise HTTPError(404, 'no such camera')
             # block access to admin-only cameras for non-admin users
             camera_config = config.get_camera(camera_id)
-            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+            if (
+                camera_config
+                and camera_config.get('@admin_only')
+                and self.current_user != 'admin'
+            ):
                 raise HTTPError(403, 'access denied')
 
         if op == 'delete':

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -47,6 +47,10 @@ class PictureHandler(BaseHandler):
             camera_id = int(camera_id)
             if camera_id not in config.get_camera_ids():
                 raise HTTPError(404, 'no such camera')
+            # block access to admin-only cameras for non-admin users
+            camera_config = config.get_camera(camera_id)
+            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+                raise HTTPError(403, 'access denied')
 
         if op == 'current':
             await self.current(camera_id)
@@ -80,6 +84,10 @@ class PictureHandler(BaseHandler):
             camera_id = int(camera_id)
             if camera_id not in config.get_camera_ids():
                 raise HTTPError(404, 'no such camera')
+            # block access to admin-only cameras for non-admin users
+            camera_config = config.get_camera(camera_id)
+            if camera_config and camera_config.get('@admin_only') and self.current_user != 'admin':
+                raise HTTPError(403, 'access denied')
 
         if op == 'delete':
             await self.delete(camera_id, filename)
@@ -220,6 +228,9 @@ class PictureHandler(BaseHandler):
                     camera_config=camera_config,
                     title=self.get_argument('title', ''),
                 )
+            # block access to admin-only cameras for non-admin users
+            if resp.remote_ui_config.get('admin_only') and self.current_user != 'admin':
+                raise HTTPError(403, 'access denied')
 
             # issue a fake motion_camera_ui_to_dict() call to transform
             # the remote UI values into motion config directives

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -243,7 +243,7 @@ class PictureHandler(BaseHandler):
                     title=self.get_argument('title', ''),
                 )
             # block access to admin-only cameras for non-admin users
-            if resp.remote_ui_config.get('admin_only') and self.current_user != 'admin':
+            if camera_config.get('admin_only') and self.current_user != 'admin':
                 raise HTTPError(
                     403, f'access denied to admin-only camera frame "{camera_id}"'
                 )

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -54,7 +54,10 @@ class PictureHandler(BaseHandler):
                 and camera_config.get('@admin_only')
                 and self.current_user != 'admin'
             ):
-                raise HTTPError(403, 'access denied')
+                raise HTTPError(
+                    403,
+                    f'GET access denied to admin-only camera "{camera_id}" for operation "{op}"',
+                )
 
         if op == 'current':
             await self.current(camera_id)
@@ -95,7 +98,10 @@ class PictureHandler(BaseHandler):
                 and camera_config.get('@admin_only')
                 and self.current_user != 'admin'
             ):
-                raise HTTPError(403, 'access denied')
+                raise HTTPError(
+                    403,
+                    f'POST access denied to admin-only camera "{camera_id}" for operation "{op}"',
+                )
 
         if op == 'delete':
             await self.delete(camera_id, filename)
@@ -238,7 +244,9 @@ class PictureHandler(BaseHandler):
                 )
             # block access to admin-only cameras for non-admin users
             if resp.remote_ui_config.get('admin_only') and self.current_user != 'admin':
-                raise HTTPError(403, 'access denied')
+                raise HTTPError(
+                    403, f'access denied to admin-only camera frame "{camera_id}"'
+                )
 
             # issue a fake motion_camera_ui_to_dict() call to transform
             # the remote UI values into motion config directives

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1928,6 +1928,7 @@ function cameraUi2Dict() {
     var dict = {
         'enabled': $('#videoDeviceEnabledSwitch')[0].checked,
         'name': $('#deviceNameEntry').val(),
+        'admin_only': $('#adminOnlySwitch')[0].checked,
         'proto': $('#deviceTypeEntry')[0].proto,
 
         /* video device */
@@ -2229,6 +2230,7 @@ function dict2CameraUi(dict) {
     $('#deviceUrlEntry').val(dict['device_url']); markHideIfNull('device_url', 'deviceUrlEntry');
     $('#deviceTypeEntry').val(prettyType); markHideIfNull(!prettyType, 'deviceTypeEntry');
     $('#deviceTypeEntry')[0].proto = dict['proto'];
+    $('#adminOnlySwitch')[0].checked = dict['admin_only']; markHideIfNull('admin_only', 'adminOnlySwitch');
     $('#autoBrightnessSwitch')[0].checked = dict['auto_brightness']; markHideIfNull('auto_brightness', 'autoBrightnessSwitch');
 
     $('#resolutionSelect').html('');

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -287,6 +287,11 @@
                             <td class="settings-item-value"><input type="text" class="styled device camera-config" id="deviceTypeEntry" readonly="readonly"></td>
                         </tr>
                         <tr class="settings-item">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Admin only access") }}</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="adminOnlySwitch"></td>
+                            <td><span class="help-mark" title="{{ _("If enabled only the admin user can access this camera") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item">
                             <td colspan="100"><div class="settings-item-separator"></div></td>
                         </tr>
                         <tr class="settings-item">

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -287,7 +287,7 @@
                             <td class="settings-item-value"><input type="text" class="styled device camera-config" id="deviceTypeEntry" readonly="readonly"></td>
                         </tr>
                         <tr class="settings-item">
-                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Admin only access") }}</span></td>
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Admin-only access") }}</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="adminOnlySwitch"></td>
                             <td><span class="help-mark" title="{{ _("If enabled only the admin user can access this camera") }}">?</span></td>
                         </tr>


### PR DESCRIPTION
This PR introduces an admin_only camera-level access control flag and enforces its use consistently across the UI, configuration storage, and backend handlers.

Cameras marked as admin-only are hidden from non-admin users in camera listings and blocked from use when accessing actions, pictures, movies, movie playback, live frames, and embedded views.
The flag is configurable via the UI, stored as @admin_only, and disabled by default for newly created cameras.

The admin_only flag is treated as a local-only, per-camera setting. It is not synchronized from or to remote motionEye instances, ensuring compatibility with older remotes and preventing ambiguous behavior when the flag is unsupported remotely. The locally configured value is always preserved, allowing local and remote instances to manage access independently. 

Access control is enforced on the server side: non-admin users attempting to access admin-only cameras receive HTTP 403 (access denied).

Please let me know if I missed anything 😅
This feature was also discussed in #2959.