### PR TITLE
Fix current picture retry logic

### DIFF
--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -20,7 +20,7 @@ import logging
 import os
 import re
 
-from tornado.ioloop import IOLoop
+from tornado import gen
 from tornado.web import HTTPError
 
 from motioneye import (
@@ -115,12 +115,8 @@ class PictureHandler(BaseHandler):
             # get_current_picture() will make sure to start a client, but a jpeg frame is not available right away;
             # wait at most 5 seconds and retry every 200 ms.
             if not picture and retry < 25:
-                return IOLoop.current().add_timeout(
-                    datetime.timedelta(seconds=0.2),
-                    self.current,
-                    camera_id=camera_id,
-                    retry=retry + 1,
-                )
+                await gen.sleep(0.2)
+                return await self.current(camera_id=camera_id, retry=retry + 1)
 
             self.set_cookie(
                 'motion_detected_' + camera_id_str,


### PR DESCRIPTION
Fixes an issue where /picture/\<id\>/current did not return JPEG images when no frame was available yet.

The retry logic previously used `IOLoop.add_timeout()`, which scheduled a retry but immediately closed the HTTP request.
As a result, the client could receive a response with Content-Type: image/jpeg but an empty body.

The retry now runs within the same request using an awaited sleep, keeping the request open while waiting for the first JPEG frame from the internal MJPEG client, up to the intended retry limit.

This behavior matches the existing comment in the code, and I think it reflects the intended behavior?:

https://github.com/motioneye-project/motioneye/blob/4f1b7b50182a6a23cddf3fa88fb0b40f0e667a20/motioneye/handlers/picture.py#L114-L116

#2978
