### PR TITLE
fix(mjpegclient): strip leading space from digest parameter keys

### DIFF
--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -240,7 +240,7 @@ class MjpgClient(IOStream):
         if data.startswith('Digest'):
             logging.debug('mjpg client using digest authentication')
 
-            parts = data[7:].split(',')
+            parts = [p.strip() for p in data[7:].split(',')]
             parts_dict = dict(p.split('=', 1) for p in parts)
             parts_dict = {p[0]: p[1].strip('"') for p in list(parts_dict.items())}
 


### PR DESCRIPTION
After splitting parameters key-value pairs by comma, they have a leading space. It remains as part of the key in the resulting dictionary, breaking `utils.build_digest_header()`.

This change strips spaces from each key-value pair before creating the dictionary.

Before:
```
dict: {'realm': 'Motion', ' qop': 'auth', ' algorithm': 'MD5', ' nonce': '7c1781f7ebe05a8eb69d3f333038702b000000000888', ' opaque': '025f5245013b0a6c'}
```
After:
```
dict: {'realm': 'Motion', 'qop': 'auth', 'algorithm': 'MD5', 'nonce': '23878120785322c2082803516d0d70d3000000004954', 'opaque': '00950ecd01493b25'}
```