### PR TITLE
fix(mjpgclient): keep alive digest auth connection

### DIFF
--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -14,12 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
-import errno
 import logging
-import re
 import socket
-import time
+from datetime import timedelta
+from errno import ECONNREFUSED
+from re import findall, match
+from time import time
 from typing import Any, Tuple
 
 from tornado.concurrent import Future
@@ -72,15 +72,15 @@ class MjpgClient(IOStream):
                 f'mjpg client for camera {self._camera_id} on port {self._port} removed'
             )
 
-        if getattr(self, 'error', None) and self.error.errno != errno.ECONNREFUSED:
-            now = time.time()
+        if getattr(self, 'error', None) and self.error.errno != ECONNREFUSED:
+            now = time()
             if (
                 now - MjpgClient._last_erroneous_close_time
                 < settings.MJPG_CLIENT_TIMEOUT
             ):
-                msg = f'connection problem detected for mjpg client for camera {self._camera_id} on port {self._port}'
-
-                logging.error(msg)
+                logging.error(
+                    f'connection problem detected for mjpg client for camera {self._camera_id} on port {self._port}'
+                )
 
                 if settings.MOTION_RESTART_ON_ERRORS:
                     motionctl.stop(
@@ -91,7 +91,7 @@ class MjpgClient(IOStream):
             MjpgClient._last_erroneous_close_time = now
 
     def get_last_jpg(self):
-        self._last_access = time.time()
+        self._last_access = time()
         return self._last_jpg
 
     def get_last_access(self):
@@ -99,7 +99,7 @@ class MjpgClient(IOStream):
 
     def get_last_jpg_time(self):
         if not self._last_jpg_times:
-            self._last_jpg_times.append(time.time())
+            self._last_jpg_times.append(time())
 
         return self._last_jpg_times[-1]
 
@@ -107,7 +107,7 @@ class MjpgClient(IOStream):
         if len(self._last_jpg_times) < self._FPS_LEN:
             return 0  # not enough "samples"
 
-        if time.time() - self._last_jpg_times[-1] > 1:
+        if time() - self._last_jpg_times[-1] > 1:
             return 0  # everything below 1 fps is considered 0
 
         return (len(self._last_jpg_times) - 1) / (
@@ -171,18 +171,18 @@ class MjpgClient(IOStream):
             logging.debug('mjpg client using basic authentication')
             auth_header = utils.build_basic_header(self._username, self._password)
             self.write(
-                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
+                f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\n\r\n'.encode()
             )
 
         elif (
             self._auth_mode == 'digest'
         ):  # in digest auth mode, the header is built upon receiving 401
             logging.debug('digest authentication _on_connect')
-            self.write(b'GET / HTTP/1.0\r\n\r\n')
+            self.write(b'GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n')
 
         else:  # no authentication
             logging.debug('no authentication _on_connect')
-            self.write(b'GET / HTTP/1.0\r\nConnection: close\r\n\r\n')
+            self.write(b'GET / HTTP/1.0\r\n\r\n')
 
         self._seek_http()
 
@@ -225,12 +225,12 @@ class MjpgClient(IOStream):
 
         data = data.strip()
 
-        m = re.match(br'Basic\s*realm="([a-zA-Z0-9\-\s]+)"', data)
+        m = match(br'Basic\s*realm="([a-zA-Z0-9\-\s]+)"', data)
         if m:
             logging.debug('mjpg client using basic authentication')
 
             auth_header = utils.build_basic_header(self._username, self._password)
-            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
+            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\n\r\n'.encode()
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 
@@ -249,7 +249,7 @@ class MjpgClient(IOStream):
             auth_header = utils.build_digest_header(
                 'GET', '/', self._username, self._password, self._auth_digest_state
             )
-            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\nConnection: close\r\n\r\n'.encode()
+            w_data = f'GET / HTTP/1.0\r\nAuthorization: {auth_header}\r\n\r\n'.encode()
             w_future = utils.cast_future(self.write(w_data))
             w_future.add_done_callback(self._seek_http)
 
@@ -278,7 +278,7 @@ class MjpgClient(IOStream):
         if not result or self._check_error():
             return
 
-        matches = re.findall(rb'(\d+)', data)
+        matches = findall(rb'(\d+)', data)
         if not matches:
             self._error(f'could not find content length in mjpg header line "{data}"')
 
@@ -295,7 +295,7 @@ class MjpgClient(IOStream):
             return
 
         self._last_jpg = data
-        self._last_jpg_times.append(time.time())
+        self._last_jpg_times.append(time())
         while len(self._last_jpg_times) > self._FPS_LEN:
             self._last_jpg_times.pop(0)
 
@@ -306,7 +306,7 @@ def start():
     # schedule the garbage collector
     io_loop = IOLoop.current()
     io_loop.add_timeout(
-        datetime.timedelta(seconds=settings.MJPG_CLIENT_TIMEOUT), _garbage_collector
+        timedelta(seconds=settings.MJPG_CLIENT_TIMEOUT), _garbage_collector
     )
 
 
@@ -367,10 +367,10 @@ def close_all(invalidate=False):
 def _garbage_collector():
     io_loop = IOLoop.current()
     io_loop.add_timeout(
-        datetime.timedelta(seconds=settings.MJPG_CLIENT_TIMEOUT), _garbage_collector
+        timedelta(seconds=settings.MJPG_CLIENT_TIMEOUT), _garbage_collector
     )
 
-    now = time.time()
+    now = time()
     for camera_id, client in list(MjpgClient.clients.items()):
         logging.debug(f'_garbage_collector checking camera. id: {camera_id}')
         port = client.get_port()
@@ -398,17 +398,10 @@ def _garbage_collector():
             settings.MJPG_CLIENT_IDLE_TIMEOUT
             and delta > settings.MJPG_CLIENT_IDLE_TIMEOUT
         ):
-            msg = (
-                'mjpg client for camera %(camera_id)s on port %(port)s has been idle '
-                'for %(timeout)s seconds, removing it'
-                % {
-                    'camera_id': camera_id,
-                    'port': port,
-                    'timeout': settings.MJPG_CLIENT_IDLE_TIMEOUT,
-                }
+            logging.debug(
+                f'mjpg client for camera {camera_id} on port {port} has been idle'
+                f' for {settings.MJPG_CLIENT_IDLE_TIMEOUT} seconds, removing it'
             )
-
-            logging.debug(msg)
 
             client.close()
 


### PR DESCRIPTION
In #2432, we switched from HTTP/1.1 to HTTP/1.0 to avoid chunks used by `libmicrohttp` (used by `motion`) since v0.9.74, breaking our `Content-Length` based parsing.

This as well changed the default Connection header from `keep-alive` to `close`. Since we otherwise add `Connection: close` explicitly, this changed the connection type for digest authentication only.

With digest authentication, we need to wait for a 401 with a nonce to build the Authorization header, hence the connection needs to stay open. This commit hence adds `Connection: keep-alive` in that case to restore the pre-#2432 behavior.

Additionally, the now redundant `Connection: close` header is removed to save a few bytes.

Additionally, imports are switched to individual methods/constants where applicable, and the code to generate log messages is consolidated in two cases, making use of f-strings and avoiding intermediate variables.