### PR TITLE
Add separate per-camera streaming credentials for Motion stream_authentication 

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -990,8 +990,8 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         if not streaming_username:
             streaming_username = prev_stream_username
 
-        # UI often sends '*****' or omits the password when unchanged.
-        if not streaming_password or streaming_password == '*****':
+        # UI omits the password when unchanged.
+        if not streaming_password:
             streaming_password = prev_stream_password
 
         # No hard fail: if still missing, keep stream_authentication empty.

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -930,9 +930,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         'stream_auth_method': {'disabled': 0, 'basic': 1, 'digest': 2}.get(
             ui['streaming_auth_mode'], 0
         ),
-        'stream_authentication': main_config['@normal_username']
-        + ':'
-        + main_config['@normal_password'],
+        'stream_authentication': '',
         '@lang': main_config['@lang'],
         # still images
         'picture_output': False,
@@ -979,6 +977,28 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         'on_movie_end': '',
         'on_picture_save': '',
     }
+
+    if data.get('stream_auth_method', 0) > 0:
+        streaming_username = ui.get('streaming_username')
+        streaming_password = ui.get('streaming_password')
+
+        prev_stream_authentication = prev_config.get('stream_authentication')
+        parts = (prev_stream_authentication or '').split(':', 1)
+        prev_stream_username = parts[0]
+        prev_stream_password = parts[1] if len(parts) > 1 else ''
+
+        if not streaming_username:
+            streaming_username = prev_stream_username
+
+        # UI often sends '*****' or omits the password when unchanged.
+        if not streaming_password or streaming_password == '*****':
+            streaming_password = prev_stream_password
+
+        # No hard fail: if still missing, keep stream_authentication empty.
+        if streaming_username and streaming_password:
+            data['stream_authentication'] = (
+                str(streaming_username) + ':' + str(streaming_password)
+            )
 
     if utils.is_v4l2_camera(prev_config):
         proto = 'v4l2'
@@ -1390,7 +1410,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
     return prev_config
 
 
-def motion_camera_dict_to_ui(data):
+def motion_camera_dict_to_ui(data):  # noqa: C901
     ui = {
         # device
         'name': data['camera_name'],
@@ -1449,6 +1469,8 @@ def motion_camera_dict_to_ui(data):
         'streaming_auth_mode': {0: 'disabled', 1: 'basic', 2: 'digest'}.get(
             data.get('stream_auth_method'), 'disabled'
         ),
+        'streaming_username': '',
+        'streaming_password': '',
         'streaming_motion': int(data['stream_motion']),
         # still images
         'still_images': False,
@@ -1509,6 +1531,14 @@ def motion_camera_dict_to_ui(data):
         'sunday_from': '',
         'sunday_to': '',
     }
+
+    stream_authentication = data.get('stream_authentication') or ''
+    if stream_authentication:
+        parts = stream_authentication.split(':', 1)
+        streaming_username = parts[0]
+        streaming_password = parts[1] if len(parts) > 1 else ''
+        ui['streaming_username'] = streaming_username
+        ui['streaming_password'] = '*****' if streaming_password else ''
 
     if utils.is_net_camera(data):
         ui['device_url'] = data['netcam_url']
@@ -2309,7 +2339,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_sse_c_key', '')
     data.setdefault('@clean_cloud_enabled', False)
 
-    data.setdefault('stream_localhost', False)
+    data.setdefault('stream_localhost', True)
     data.setdefault('stream_port', 9080 + camera_id)
     data.setdefault('stream_maxrate', 5)
     data.setdefault('stream_quality', 85)

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -245,24 +245,7 @@ class ConfigHandler(BaseHandler):
                 reload = True
 
             if normal_username != old_normal_username or normal_password is not None:
-                logging.debug(
-                    'surveillance credentials changed, all camera configs must be updated'
-                )
-
-                # reconfigure all local cameras to update the stream authentication options
-                for camera_id in config.get_camera_ids():
-                    local_config = config.get_camera(camera_id)
-                    if not utils.is_local_motion_camera(local_config):
-                        continue
-
-                    ui_config = config.motion_camera_dict_to_ui(local_config)
-                    local_config = config.motion_camera_ui_to_dict(
-                        ui_config, local_config
-                    )
-
-                    config.set_camera(camera_id, local_config)
-
-                    restart = True
+                logging.debug('surveillance credentials changed')
 
             if reboot and settings.ENABLE_REBOOT:
                 logging.debug('system settings changed, reboot needed')

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -330,9 +330,9 @@ def get_jpg(camera_id):
         username, password = None, None
         auth_mode = None
         if camera_config.get('stream_auth_method') > 0:
-            username, password = camera_config.get('stream_authentication', ':').split(
-                ':'
-            )
+            parts = (camera_config.get('stream_authentication') or '').split(':', 1)
+            username = parts[0]
+            password = parts[1] if len(parts) > 1 else ''
             auth_mode = (
                 'digest' if camera_config.get('stream_auth_method') > 1 else 'basic'
             )

--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -234,7 +234,7 @@ async def get_motion_detection(camera_id) -> utils.GetMotionDetectionResult:
     enabled = bool(resp_body.lower().count('active'))
 
     logging.debug(
-        f"motion detection is {['disabled', 'enabled'][enabled]} for camera with id {id}"
+        f"motion detection is {['disabled', 'enabled'][enabled]} for camera with id {camera_id}"
     )
 
     return utils.GetMotionDetectionResult(enabled, None)

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -614,10 +614,6 @@ function initUI() {
         return true;
     }, '');
     makeCustomValidator($('#streamingUsernameEntry'), function (value) {
-        if (!value) {
-            return true;
-        }
-
         if (String(value).indexOf(':') >= 0) {
             return i18n.gettext("use of colon (:) is not allowed in video streaming username");
         }
@@ -626,14 +622,6 @@ function initUI() {
     }, '');
     makeCustomValidator($('#streamingAuthModeSelect'), function (value) {
         if (!$('#adminOnlySwitch')[0].checked) {
-            return true;
-        }
-
-        if (!$('#videoDeviceEnabledSwitch')[0].checked) {
-            return true;
-        }
-
-        if (!$('#videoStreamingEnabledSwitch')[0].checked) {
             return true;
         }
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -7,6 +7,7 @@ var pushConfigs = {};
 var pushConfigReboot = false;
 var adminPasswordChanged = {};
 var normalPasswordChanged = {};
+var streamingPasswordChanged = {};
 var refreshDisabled = {}; /* dictionary indexed by cameraId, tells if refresh is disabled for a given camera */
 var singleViewCameraId = null;
 var fullScreenMode = false;
@@ -605,9 +606,39 @@ function initUI() {
     makeTimeValidator($('input[type=text].time'));
 
     /* custom validators */
-    makeCustomValidator($('#adminPasswordEntry, #normalPasswordEntry'), function (value) {
+    makeCustomValidator($('#adminPasswordEntry, #normalPasswordEntry, #streamingPasswordEntry'), function (value) {
         if (!value.toLowerCase().match(new RegExp('^[\x21-\x7F]*$'))) {
             return i18n.gettext("specialaj signoj ne rajtas en pasvorto");
+        }
+
+        return true;
+    }, '');
+    makeCustomValidator($('#streamingUsernameEntry'), function (value) {
+        if (!value) {
+            return true;
+        }
+
+        if (String(value).indexOf(':') >= 0) {
+            return i18n.gettext("use of colon (:) is not allowed in video streaming username");
+        }
+
+        return true;
+    }, '');
+    makeCustomValidator($('#streamingAuthModeSelect'), function (value) {
+        if (!$('#adminOnlySwitch')[0].checked) {
+            return true;
+        }
+
+        if (!$('#videoDeviceEnabledSwitch')[0].checked) {
+            return true;
+        }
+
+        if (!$('#videoStreamingEnabledSwitch')[0].checked) {
+            return true;
+        }
+
+        if (value != 'basic' && value != 'digest') {
+            return i18n.gettext("video streaming authentication mode must be Basic or Digest when admin-only access is enabled");
         }
 
         return true;
@@ -725,10 +756,17 @@ function initUI() {
     $('#normalPasswordEntry').change(function () {
         normalPasswordChanged.change = true;
     });
+    $('#streamingPasswordEntry').keydown(function () {
+        streamingPasswordChanged.keydown = true;
+    });
+    $('#streamingPasswordEntry').change(function () {
+        streamingPasswordChanged.change = true;
+    });
 
     /* ui elements that enable/disable other ui elements */
     $('#storageDeviceSelect').change(updateConfigUI);
     $('#resolutionSelect').change(updateConfigUI);
+    $('#adminOnlySwitch').change(updateConfigUI);
     $('#leftTextTypeSelect').change(updateConfigUI);
     $('#rightTextTypeSelect').change(updateConfigUI);
     $('#captureModeSelect').change(updateConfigUI);
@@ -737,6 +775,7 @@ function initUI() {
     $('#videoDeviceEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     $('#textOverlayEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     $('#videoStreamingEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
+    $('#streamingAuthModeSelect').change(updateConfigUI);
     $('#streamingServerResizeSwitch').change(updateConfigUI);
     $('#stillImagesEnabledSwitch').change(checkMinimizeSection).change(updateConfigUI);
     $('#preservePicturesSelect').change(updateConfigUI);
@@ -2007,6 +2046,7 @@ function cameraUi2Dict() {
         'streaming_server_resize': $('#streamingServerResizeSwitch')[0].checked,
         'streaming_port': $('#streamingPortEntry').val(),
         'streaming_auth_mode': $('#streamingAuthModeSelect').val() || 'disabled', /* compatibility with old motion */
+        'streaming_username': $('#streamingUsernameEntry').val(),
         'streaming_motion': $('#streamingMotion')[0].checked,
 
         /* still images */
@@ -2091,6 +2131,10 @@ function cameraUi2Dict() {
         'sunday_to': $('#sundayEnabledSwitch')[0].checked ? $('#sundayToEntry').val() : '',
         'working_schedule_type': $('#workingScheduleTypeSelect').val()
     };
+
+    if (streamingPasswordChanged.change && streamingPasswordChanged.keydown && $('#streamingPasswordEntry').val() !== '*****') {
+        dict['streaming_password'] = $('#streamingPasswordEntry').val();
+    }
 
     /* video controls */
     var videoControls = {};
@@ -2347,6 +2391,8 @@ function dict2CameraUi(dict) {
     $('#streamingServerResizeSwitch')[0].checked = dict['streaming_server_resize']; markHideIfNull('streaming_server_resize', 'streamingServerResizeSwitch');
     $('#streamingPortEntry').val(dict['streaming_port']); markHideIfNull('streaming_port', 'streamingPortEntry');
     $('#streamingAuthModeSelect').val(dict['streaming_auth_mode']); markHideIfNull('streaming_auth_mode', 'streamingAuthModeSelect');
+    $('#streamingUsernameEntry').val(dict['streaming_username']); markHideIfNull('streaming_username', 'streamingUsernameEntry');
+    $('#streamingPasswordEntry').val(dict['streaming_password']); markHideIfNull('streaming_password', 'streamingPasswordEntry');
     $('#streamingMotion')[0].checked = dict['streaming_motion']; markHideIfNull('streaming_motion', 'streamingMotion');
 
     var cameraUrl = location.protocol + '//' + location.host + basePath + 'picture/' + dict.id + '/';
@@ -2736,6 +2782,7 @@ function doApply() {
             /* reset password change flags */
             adminPasswordChanged = {};
             normalPasswordChanged = {};
+            streamingPasswordChanged = {};
 
             if (data.reboot) {
                 var count = 0;

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -705,6 +705,16 @@
                             </td>
                             <td><span class="help-mark" title="{{ _("la aŭtentiga metodo uzata de la rivereto (elektu 'Bazic' anstataŭ 'Digest' se vi renkontas problemojn kun triaj programoj); akreditoj kontroloj estos uzataj") }}">?</span></td>
                         </tr>
+                        <tr class="settings-item" required="true" strip="true" depends="videoStreamingEnabled streamingAuthMode=(basic|digest)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Uzantnomo") }}</span></td>
+                            <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled streaming camera-config" id="streamingUsernameEntry"></td>
+                            <td><span class="help-mark" title="{{ _("username used for video streaming authentication. When Admin-only access is enabled, use credentials different from the Surveillance user.") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item" required="true" strip="true" depends="videoStreamingEnabled streamingAuthMode=(basic|digest)">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Pasvorto") }}</span></td>
+                            <td class="settings-item-value"><input type="password" autocomplete="new-password" class="styled streaming camera-config" id="streamingPasswordEntry"></td>
+                            <td><span class="help-mark" title="{{ _("password used for video streaming authentication. When Admin-only access is enabled, use credentials different from the Surveillance user.") }}">?</span></td>
+                        </tr>
                         <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Movado-Optimigo") }}</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled streaming camera-config" id="streamingMotion"></td>
@@ -722,7 +732,7 @@
                             </td>
                             <td><span class="help-mark" title="{{ _("URL kiu provizas JPEG-bildon kun la plej freŝa kaptaĵo de la kamerao") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item">
+                        <tr class="settings-item" depends="videoStreamingEnabled">
                             <td class="settings-item-label"></td>
                             <td class="settings-item-value">
                                 <div class="html styled streaming camera-config" id="streamingMjpgUrlHtml">

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -732,7 +732,7 @@
                             </td>
                             <td><span class="help-mark" title="{{ _("URL kiu provizas JPEG-bildon kun la plej freŝa kaptaĵo de la kamerao") }}">?</span></td>
                         </tr>
-                        <tr class="settings-item" depends="videoStreamingEnabled">
+                        <tr class="settings-item">
                             <td class="settings-item-label"></td>
                             <td class="settings-item-value">
                                 <div class="html styled streaming camera-config" id="streamingMjpgUrlHtml">


### PR DESCRIPTION
This change introduces separate credentials for Motion MJPEG video streaming instead of reusing the Surveillance (normal) user credentials. When video streaming authentication is set to Basic or Digest, the GUI displays dedicated streaming username and password fields. These credentials are stored per camera in the camera configuration.

When Admin-only access is enabled, the video streaming authentication mode must be set to Basic or Digest.

Streaming authentication parsing has been updated to split only on the first `:`, ensuring that only the first colon separates username and password. This allows `:` characters in the streaming password but not in the username. 

By default, the stream remains bound to localhost. A minor logging message was also corrected.

Additionally, I added `# noqa: C901` to `motion_camera_dict_to_ui` to silence the pre-commit cyclomatic complexity warning. A proper refactor of this function can hopefully be addressed in a separate PR to keep this diff focused and minimal for now.