### PR TITLE
Percent-encode netcam_userpass

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -687,7 +687,7 @@ def add_camera(device_details):
             raw_password = str(device_details['password'])
 
             # Motion's mjpeg/mjpg/jpeg/ftp auth handling expects plain userpass here.
-            if match(r'^(mjpeg|mjpg|jpeg|ftp)://', camera_config['netcam_url'].lower()):
+            if camera_config['netcam_url'].startswith(('mjpeg', 'mjpg', 'jpeg', 'ftp')):
                 userpass = f"{raw_username}:{raw_password}"
             else:
                 # For other protocols, credentials go to ffmpeg as URL userinfo,

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -24,7 +24,7 @@ import subprocess
 from errno import EEXIST, ENOENT
 from re import match, sub
 from shlex import split
-from urllib.parse import urlunparse
+from urllib.parse import quote, urlunparse
 
 from tornado.ioloop import IOLoop
 
@@ -683,9 +683,25 @@ def add_camera(device_details):
         camera_config['netcam_url'] = device_details['url']
 
         if device_details['username']:
-            camera_config['netcam_userpass'] = (
-                device_details['username'] + ':' + device_details['password']
-            )
+            raw_username = str(device_details['username'])
+            raw_password = str(device_details['password'])
+
+            # Motion's mjpeg/mjpg/jpeg/ftp auth handling expects plain userpass here.
+            if match(r'^(mjpeg|mjpg|jpeg|ftp)://', camera_config['netcam_url'].lower()):
+                userpass = f"{raw_username}:{raw_password}"
+            else:
+                # For other protocols, credentials go to ffmpeg as URL userinfo,
+                # so reserved characters (e.g. "@", "#") must be percent-encoded.
+                username = quote(raw_username, safe='')
+                password = quote(raw_password, safe='')
+                userpass = f'{username}:{password}'
+
+                if username != raw_username or password != raw_password:
+                    logging.debug(
+                        f'credentials for camera {camera_id} have been percent-encoded'
+                    )
+
+            camera_config['netcam_userpass'] = userpass
 
         camera_config['netcam_keepalive'] = device_details.get('keep_alive', False)
         camera_config['netcam_tolerant_check'] = True


### PR DESCRIPTION
When adding a netcam camera, username and password are now [percent-encoded](https://docs.python.org/3/library/urllib.parse.html#url-quoting) when constructing `netcam_userpass` for protocols where Motion embeds credentials into the URL as `userinfo` and passes that URL to `ffmpeg` (notably `rtsp` and `rtmp`).

[Reserved characters](https://docs.mapp.com/docs/url-encoding-and-what-characters-are-valid-in-a-uri) such as `@`, `#`, or `!` can break URL parsing and authentication when included directly in the URL as `userinfo`. Percent-encoding ensures credentials are safely passed to `ffmpeg`.

For `mjpeg`, `mjpg`, `jpeg`, `ftp`, credentials are unchanged since these are handled directly by Motion’s native netcam [implementation](https://github.com/Motion-Project/motion/blob/04e4a05d71a534b88158fb2ae29481c83d526c5c/src/motion.c#L776-L783) and not passed to ffmpeg. (Although I don’t think MotionEye currently supports adding all of these formats yet, so this check may be redundant, please share your thoughts.)

A debug message is logged only when encoding actually modifies the credentials.

Please see issue #2972 for more information.