### PR TITLE
Make admin username editable in GUI

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -2298,10 +2298,10 @@ def _dict_to_conf(lines, data, list_names=None):
 def _set_default_motion(data):
     data.setdefault('@enabled', True)
 
-    data.setdefault('@admin_username', os.getenv('MOTIONEYE_ADMIN_USERNAME', 'admin'))
-    data.setdefault('@admin_password', os.getenv('MOTIONEYE_ADMIN_PASSWORD', ''))
-    data.setdefault('@normal_username', os.getenv('MOTIONEYE_NORMAL_USERNAME', 'user'))
-    data.setdefault('@normal_password', os.getenv('MOTIONEYE_NORMAL_PASSWORD', ''))
+    data.setdefault('@admin_username', 'admin')
+    data.setdefault('@admin_password', '')
+    data.setdefault('@normal_username', 'user')
+    data.setdefault('@normal_password', '')
     data.setdefault('@lang', 'en')
 
     data.setdefault('setup_mode', False)

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -2298,10 +2298,10 @@ def _dict_to_conf(lines, data, list_names=None):
 def _set_default_motion(data):
     data.setdefault('@enabled', True)
 
-    data.setdefault('@admin_username', 'admin')
-    data.setdefault('@admin_password', '')
-    data.setdefault('@normal_username', 'user')
-    data.setdefault('@normal_password', '')
+    data.setdefault('@admin_username', os.getenv('MOTIONEYE_ADMIN_USERNAME', 'admin'))
+    data.setdefault('@admin_password', os.getenv('MOTIONEYE_ADMIN_PASSWORD', ''))
+    data.setdefault('@normal_username', os.getenv('MOTIONEYE_NORMAL_USERNAME', 'user'))
+    data.setdefault('@normal_password', os.getenv('MOTIONEYE_NORMAL_PASSWORD', ''))
     data.setdefault('@lang', 'en')
 
     data.setdefault('setup_mode', False)

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -174,7 +174,7 @@
                         </tr>
                         <tr class="settings-item" required="true" strip="true">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Administranto") }}</span></td>
-                            <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled general main-config" id="adminUsernameEntry" readonly="readonly"></td>
+                            <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled general main-config" id="adminUsernameEntry"></td>
                             <td><span class="help-mark" title="{{ _("la uzantnomo uzata por agordi la sistemon") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" strip="true">


### PR DESCRIPTION
This commit was done with an anonymous account in context of a study. The actual author might want to open a PR with its true account for proper credits, after the study ended. However, I am opening this here to show that this issue has been addressed, so no one starts doubled work 😉.