### PR TITLE
Basic Authentication: Fix base64 decoding method in utils

### DIFF
--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -298,7 +298,7 @@ def parse_basic_header(header):
     encoded = parts[1]
 
     try:
-        decoded = base64.decodebytes(encoded)
+        decoded = base64.b64decode(encoded).decode('utf-8')
 
     except:
         return None

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -298,7 +298,7 @@ def parse_basic_header(header):
     encoded = parts[1]
 
     try:
-        decoded = base64.b64decode(encoded).decode('utf-8')
+        decoded = base64.b64decode(encoded).decode()
 
     except:
         return None


### PR DESCRIPTION
`base64.decodebytes` expects bytes input, but string is being passed which voids the basic authentication. This PR fixes it and lets Basic authentication to work again.