### PR TITLE
enh(handlers): prevent path traversal in API

### DIFF
--- a/motioneye/handlers/movie.py
+++ b/motioneye/handlers/movie.py
@@ -28,6 +28,11 @@ __all__ = ('MovieHandler',)
 
 class MovieHandler(BaseHandler):
     async def get(self, camera_id, op, filename=None):
+        if filename is not None and '..' in filename.split('/'):
+            raise HTTPError(
+                403, 'Path traversal detected', reason='Path traversal detected'
+            )
+
         if camera_id is not None:
             camera_id = int(camera_id)
             if camera_id not in config.get_camera_ids():
@@ -56,6 +61,20 @@ class MovieHandler(BaseHandler):
             raise HTTPError(400, 'unknown operation')
 
     async def post(self, camera_id, op, filename=None, group=None):
+        if filename is not None and '..' in filename.split('/'):
+            raise HTTPError(
+                403,
+                f'Path traversal detected in filename "{filename}"',
+                reason='Path traversal detected',
+            )
+
+        if group is not None and '..' in group.split('/'):
+            raise HTTPError(
+                403,
+                f'Path traversal detected in group "{group}"',
+                reason='Path traversal detected',
+            )
+
         if group == '/':  # ungrouped
             group = ''
 

--- a/motioneye/handlers/movie_playback.py
+++ b/motioneye/handlers/movie_playback.py
@@ -36,6 +36,11 @@ class MoviePlaybackHandler(StaticFileHandler, BaseHandler):
 
     @BaseHandler.auth()
     async def get(self, camera_id, filename=None, include_body=True):
+        if filename is not None and '..' in filename.split('/'):
+            raise HTTPError(
+                403, 'Path traversal detected', reason='Path traversal detected'
+            )
+
         logging.debug(
             'downloading movie {filename} of camera {id}'.format(
                 filename=filename, id=camera_id

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -43,6 +43,16 @@ class PictureHandler(BaseHandler):
         return None
 
     async def get(self, camera_id, op, filename=None, group=None):
+        if filename is not None and '..' in filename.split('/'):
+            raise HTTPError(
+                403, 'Path traversal detected', reason='Path traversal detected'
+            )
+
+        if group is not None and '..' in group.split('/'):
+            raise HTTPError(
+                403, 'Path traversal detected', reason='Path traversal detected'
+            )
+
         if camera_id is not None:
             camera_id = int(camera_id)
             if camera_id not in config.get_camera_ids():
@@ -84,6 +94,20 @@ class PictureHandler(BaseHandler):
             raise HTTPError(400, 'unknown operation')
 
     async def post(self, camera_id, op, filename=None, group=None):
+        if filename is not None and '..' in filename.split('/'):
+            raise HTTPError(
+                403,
+                f'Path traversal detected in filename "{filename}"',
+                reason='Path traversal detected',
+            )
+
+        if group is not None and '..' in group.split('/'):
+            raise HTTPError(
+                403,
+                f'Path traversal detected in group "{group}"',
+                reason='Path traversal detected',
+            )
+
         if group == '/':  # ungrouped
             group = ''
 

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -425,6 +425,9 @@ def cleanup_media(media_type: str) -> None:
 
 
 def make_movie_preview(camera_config: dict, full_path: str) -> typing.Union[str, None]:
+    if '..' in full_path.split('/'):
+        raise Exception(f'Path traversal detected in full_path "{full_path}"')
+
     framerate = camera_config['framerate']
     pre_capture = camera_config['pre_capture']
     offs = pre_capture / framerate
@@ -499,6 +502,9 @@ def list_media(
     prefix: str | None = None,
     with_stat: bool = True,
 ) -> typing.Awaitable:
+    if prefix is not None and '..' in prefix.split('/'):
+        raise Exception(f'Path traversal detected in prefix "{prefix}"')
+
     fut: Future = Future()
     target_dir = camera_config.get('target_dir')
 
@@ -557,17 +563,20 @@ def list_media(
     return fut
 
 
-def get_media_path(camera_config, path, media_type):
+def get_media_path(camera_config, path: str, media_type):
+    if '..' in path.split('/'):
+        raise Exception(f'Path traversal detected in path "{path}"')
+
     target_dir = camera_config.get('target_dir')
     full_path = os.path.join(target_dir, path)
     return full_path
 
 
-def get_media_content(camera_config, path, media_type):
-    target_dir = camera_config.get('target_dir')
+def get_media_content(camera_config, path: str, media_type):
+    if '..' in path.split('/'):
+        raise Exception(f'Path traversal detected in path "{path}"')
 
-    if '..' in path:
-        raise Exception('invalid media path')
+    target_dir = camera_config.get('target_dir')
 
     full_path = os.path.join(target_dir, path)
 
@@ -584,6 +593,9 @@ def get_media_content(camera_config, path, media_type):
 def get_zipped_content(
     camera_config: dict, media_type: str, group: str
 ) -> typing.Awaitable:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     fut: Future = Future()
     target_dir = camera_config.get('target_dir')
 
@@ -640,7 +652,10 @@ def get_zipped_content(
     return fut
 
 
-def make_timelapse_movie(camera_config, framerate, interval, group):
+def make_timelapse_movie(camera_config, framerate, interval, group: str):
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     global _timelapse_process
     global _timelapse_data
 
@@ -658,7 +673,7 @@ def make_timelapse_movie(camera_config, framerate, interval, group):
     _timelapse_process = multiprocessing.Process(
         target=_do_list_pictures, args=(child_pipe, target_dir, group)
     )
-    _timelapse_process.progress = 0
+    setattr(_timelapse_process, 'progress', 0)
     _timelapse_process.start()
     _timelapse_data = None
 
@@ -866,7 +881,10 @@ def check_timelapse_movie():
         return {'progress': -1, 'data': _timelapse_data}
 
 
-def get_media_preview(camera_config, path, media_type, width, height):
+def get_media_preview(camera_config, path: str, media_type, width, height):
+    if '..' in path.split('/'):
+        raise Exception(f'Path traversal detected in path "{path}"')
+
     target_dir = camera_config.get('target_dir')
     full_path = os.path.join(target_dir, path)
 
@@ -903,7 +921,7 @@ def get_media_preview(camera_config, path, media_type, width, height):
     width = width and int(float(width)) or image.size[0]
     height = height and int(float(height)) or image.size[1]
 
-    image.thumbnail((width, height), Image.BILINEAR)
+    image.thumbnail((width, height))
 
     bio = BytesIO()
     image.save(bio, format='JPEG')
@@ -911,7 +929,10 @@ def get_media_preview(camera_config, path, media_type, width, height):
     return bio.getvalue()
 
 
-def del_media_content(camera_config, path, media_type):
+def del_media_content(camera_config, path: str, media_type):
+    if '..' in path.split('/'):
+        raise Exception(f'Path traversal detected in path "{path}"')
+
     target_dir = camera_config.get('target_dir')
 
     full_path = os.path.join(target_dir, path)
@@ -949,7 +970,10 @@ def del_media_content(camera_config, path, media_type):
         raise
 
 
-def del_media_group(camera_config, group, media_type):
+def del_media_group(camera_config, group: str, media_type):
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     if media_type == 'picture':
         exts = _PICTURE_EXTS
 
@@ -1021,7 +1045,7 @@ def get_current_picture(camera_config, width, height):
     if width >= image.size[0] and height >= image.size[1]:
         return jpg  # no enlarging of the picture on the server side
 
-    image.thumbnail((width, height), Image.BICUBIC)
+    image.thumbnail((width, height))
 
     bio = BytesIO()
     image.save(bio, format='JPEG')

--- a/motioneye/remote.py
+++ b/motioneye/remote.py
@@ -392,7 +392,12 @@ async def get_current_picture(
     )
 
 
-async def list_media(local_config, media_type, prefix) -> utils.ListMediaResponse:
+async def list_media(
+    local_config, media_type, prefix: str | None = None
+) -> utils.ListMediaResponse:
+    if prefix is not None and '..' in prefix.split('/'):
+        raise Exception(f'Path traversal detected in prefix "{prefix}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -447,8 +452,11 @@ async def list_media(local_config, media_type, prefix) -> utils.ListMediaRespons
 
 
 async def get_media_content(
-    local_config, filename, media_type
+    local_config, filename: str, media_type
 ) -> utils.CommonExternalResponse:
+    if '..' in filename.split('/'):
+        raise Exception(f'Path traversal detected in filename "{filename}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -490,8 +498,11 @@ async def get_media_content(
 
 
 async def make_zipped_content(
-    local_config, media_type, group
+    local_config, media_type, group: str
 ) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -551,8 +562,11 @@ async def make_zipped_content(
 
 
 async def get_zipped_content(
-    local_config, media_type, key, group
+    local_config, media_type, key, group: str
 ) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -598,8 +612,11 @@ async def get_zipped_content(
 
 
 async def make_timelapse_movie(
-    local_config, framerate, interval, group
+    local_config, framerate, interval, group: str
 ) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -668,7 +685,12 @@ async def make_timelapse_movie(
         return utils.CommonExternalResponse(result=response)
 
 
-async def check_timelapse_movie(local_config, group) -> utils.CommonExternalResponse:
+async def check_timelapse_movie(
+    local_config, group: str
+) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -712,7 +734,12 @@ async def check_timelapse_movie(local_config, group) -> utils.CommonExternalResp
         return utils.CommonExternalResponse(result=response)
 
 
-async def get_timelapse_movie(local_config, key, group) -> utils.CommonExternalResponse:
+async def get_timelapse_movie(
+    local_config, key, group: str
+) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -758,8 +785,11 @@ async def get_timelapse_movie(local_config, key, group) -> utils.CommonExternalR
 
 
 async def get_media_preview(
-    local_config, filename, media_type, width, height
+    local_config, filename: str, media_type, width, height
 ) -> utils.CommonExternalResponse:
+    if '..' in filename.split('/'):
+        raise Exception(f'Path traversal detected in filename "{filename}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -800,8 +830,11 @@ async def get_media_preview(
 
 
 async def del_media_content(
-    local_config, filename, media_type
+    local_config, filename: str, media_type
 ) -> utils.CommonExternalResponse:
+    if '..' in filename.split('/'):
+        raise Exception(f'Path traversal detected in filename "{filename}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )
@@ -845,8 +878,11 @@ async def del_media_content(
 
 
 async def del_media_group(
-    local_config, group, media_type
+    local_config, group: str, media_type
 ) -> utils.CommonExternalResponse:
+    if '..' in group.split('/'):
+        raise Exception(f'Path traversal detected in group "{group}"')
+
     scheme, host, port, username, password, path, camera_id = _remote_params(
         local_config
     )

--- a/tests/test_handlers/test_path_traversal.py
+++ b/tests/test_handlers/test_path_traversal.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests verifying that path traversal elements in API endpoints return HTTP 403."""
+
+import json
+
+import tornado.testing
+
+from motioneye.handlers.movie import MovieHandler
+from motioneye.handlers.picture import PictureHandler
+from tests.test_handlers import HandlerTestCase
+
+
+def _assert_path_traversal_403(test_case, response):
+    """Assert the response is a 403 specifically caused by path traversal detection."""
+    test_case.assertEqual(403, response.code)
+    body = json.loads(response.body)
+    test_case.assertTrue(
+        body.get('error', '').startswith('Path traversal detected'),
+        f"Expected error starting with 'Path traversal detected', got: {body.get('error')!r}",
+    )
+
+
+class PictureHandlerPathTraversalTest(HandlerTestCase):
+    handler_cls = PictureHandler
+
+    # --- GET: plain path traversal in filename ---
+
+    def test_get_download_plain_traversal_filename(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/picture/1/download/../../etc/passwd')
+        )
+
+    def test_get_preview_plain_traversal_filename(self):
+        _assert_path_traversal_403(self, self.fetch('/picture/1/preview/../secret.jpg'))
+
+    # --- GET: URL-encoded path traversal in filename ---
+
+    def test_get_download_url_encoded_traversal_filename(self):
+        # %2e%2e decodes to '..'
+        _assert_path_traversal_403(
+            self, self.fetch('/picture/1/download/%2e%2e/etc/passwd')
+        )
+
+    def test_get_preview_url_encoded_traversal_filename_upper(self):
+        # %2E%2E decodes to '..' (uppercase hex digits)
+        _assert_path_traversal_403(
+            self, self.fetch('/picture/1/preview/%2E%2E/secret.jpg')
+        )
+
+    # --- GET: plain path traversal in group ---
+
+    def test_get_zipped_plain_traversal_group(self):
+        _assert_path_traversal_403(self, self.fetch('/picture/1/zipped/../'))
+
+    def test_get_timelapse_plain_traversal_group(self):
+        _assert_path_traversal_403(self, self.fetch('/picture/1/timelapse/../'))
+
+    # --- GET: URL-encoded path traversal in group ---
+
+    def test_get_zipped_url_encoded_traversal_group(self):
+        _assert_path_traversal_403(self, self.fetch('/picture/1/zipped/%2e%2e/'))
+
+    def test_get_timelapse_url_encoded_traversal_group_upper(self):
+        _assert_path_traversal_403(self, self.fetch('/picture/1/timelapse/%2E%2E/'))
+
+    # --- POST: plain path traversal in filename ---
+
+    def test_post_delete_plain_traversal_filename(self):
+        _assert_path_traversal_403(
+            self,
+            self.fetch('/picture/1/delete/../../etc/passwd', method='POST', body=''),
+        )
+
+    # --- POST: URL-encoded path traversal in filename ---
+
+    def test_post_delete_url_encoded_traversal_filename(self):
+        _assert_path_traversal_403(
+            self,
+            self.fetch('/picture/1/delete/%2e%2e/etc/passwd', method='POST', body=''),
+        )
+
+    # --- POST: plain path traversal in group ---
+
+    def test_post_delete_all_plain_traversal_group(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/picture/1/delete_all/../', method='POST', body='')
+        )
+
+    # --- POST: URL-encoded path traversal in group ---
+
+    def test_post_delete_all_url_encoded_traversal_group(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/picture/1/delete_all/%2e%2e/', method='POST', body='')
+        )
+
+
+class MovieHandlerPathTraversalTest(HandlerTestCase):
+    handler_cls = MovieHandler
+
+    # --- GET: plain path traversal in filename ---
+
+    def test_get_preview_plain_traversal_filename(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/movie/1/preview/../../secret.mp4')
+        )
+
+    # --- GET: URL-encoded path traversal in filename ---
+
+    def test_get_preview_url_encoded_traversal_filename(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/movie/1/preview/%2e%2e/secret.mp4')
+        )
+
+    def test_get_preview_url_encoded_traversal_filename_upper(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/movie/1/preview/%2E%2E/secret.mp4')
+        )
+
+    # --- POST: plain path traversal in filename ---
+
+    def test_post_delete_plain_traversal_filename(self):
+        _assert_path_traversal_403(
+            self,
+            self.fetch('/movie/1/delete/../../secret.mp4', method='POST', body=''),
+        )
+
+    # --- POST: URL-encoded path traversal in filename ---
+
+    def test_post_delete_url_encoded_traversal_filename(self):
+        _assert_path_traversal_403(
+            self,
+            self.fetch('/movie/1/delete/%2e%2e/secret.mp4', method='POST', body=''),
+        )
+
+    # --- POST: plain path traversal in group ---
+
+    def test_post_delete_all_plain_traversal_group(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/movie/1/delete_all/../', method='POST', body='')
+        )
+
+    # --- POST: URL-encoded path traversal in group ---
+
+    def test_post_delete_all_url_encoded_traversal_group(self):
+        _assert_path_traversal_403(
+            self, self.fetch('/movie/1/delete_all/%2e%2e/', method='POST', body='')
+        )
+
+
+if __name__ == '__main__':
+    tornado.testing.main()

--- a/tests/test_mediafiles.py
+++ b/tests/test_mediafiles.py
@@ -285,7 +285,7 @@ class TestMediaFiles(unittest.TestCase):
 class TestMediaFilesPathTraversal(unittest.TestCase):
     """Tests verifying that path traversal elements are rejected in mediafiles functions."""
 
-    _CAMERA_CONFIG = {'target_dir': '/tmp/cam', 'framerate': 2, 'pre_capture': 2}
+    _CAMERA_CONFIG = {'target_dir': '/run/cam', 'framerate': 2, 'pre_capture': 2}
 
     # Traversal inputs to test: each contains '..' as a path component.
     _FILENAME_TRAVERSALS = [

--- a/tests/test_mediafiles.py
+++ b/tests/test_mediafiles.py
@@ -21,6 +21,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 from time import time
 
+from motioneye import mediafiles
 from motioneye.mediafiles import _list_media_files
 
 
@@ -279,6 +280,124 @@ class TestMediaFiles(unittest.TestCase):
             ]
         )
         self.assertEqual(result_paths, expected_files)
+
+
+class TestMediaFilesPathTraversal(unittest.TestCase):
+    """Tests verifying that path traversal elements are rejected in mediafiles functions."""
+
+    _CAMERA_CONFIG = {'target_dir': '/tmp/cam', 'framerate': 2, 'pre_capture': 2}
+
+    # Traversal inputs to test: each contains '..' as a path component.
+    _FILENAME_TRAVERSALS = [
+        '../etc/passwd',
+        '../../etc/passwd',
+        'subdir/../../../etc/passwd',
+        '../secret.jpg',
+    ]
+    _GROUP_TRAVERSALS = [
+        '..',
+        '../group',
+        'subdir/..',
+        'subdir/../../other',
+    ]
+    _PREFIX_TRAVERSALS = [
+        '..',
+        '../prefix',
+        'prefix/../..',
+    ]
+
+    def _assert_raises_path_traversal(self, fn, *args, **kwargs):
+        with self.assertRaises(Exception) as ctx:
+            fn(*args, **kwargs)
+        self.assertIn('Path traversal', str(ctx.exception))
+
+    def test_make_movie_preview_rejects_traversal(self):
+        for full_path in self._FILENAME_TRAVERSALS:
+            with self.subTest(full_path=full_path):
+                self._assert_raises_path_traversal(
+                    mediafiles.make_movie_preview, self._CAMERA_CONFIG, full_path
+                )
+
+    def test_list_media_rejects_prefix_traversal(self):
+        for prefix in self._PREFIX_TRAVERSALS:
+            with self.subTest(prefix=prefix):
+                # list_media returns an Awaitable; the check runs before scheduling.
+                self._assert_raises_path_traversal(
+                    mediafiles.list_media,
+                    self._CAMERA_CONFIG,
+                    'picture',
+                    prefix=prefix,
+                )
+
+    def test_get_media_path_rejects_traversal(self):
+        for path in self._FILENAME_TRAVERSALS:
+            with self.subTest(path=path):
+                self._assert_raises_path_traversal(
+                    mediafiles.get_media_path, self._CAMERA_CONFIG, path, 'picture'
+                )
+
+    def test_get_media_content_rejects_traversal(self):
+        for path in self._FILENAME_TRAVERSALS:
+            with self.subTest(path=path):
+                self._assert_raises_path_traversal(
+                    mediafiles.get_media_content,
+                    self._CAMERA_CONFIG,
+                    path,
+                    'picture',
+                )
+
+    def test_get_zipped_content_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                self._assert_raises_path_traversal(
+                    mediafiles.get_zipped_content,
+                    self._CAMERA_CONFIG,
+                    'picture',
+                    group,
+                )
+
+    def test_make_timelapse_movie_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                self._assert_raises_path_traversal(
+                    mediafiles.make_timelapse_movie,
+                    self._CAMERA_CONFIG,
+                    2,
+                    1,
+                    group,
+                )
+
+    def test_get_media_preview_rejects_traversal(self):
+        for path in self._FILENAME_TRAVERSALS:
+            with self.subTest(path=path):
+                self._assert_raises_path_traversal(
+                    mediafiles.get_media_preview,
+                    self._CAMERA_CONFIG,
+                    path,
+                    'picture',
+                    None,
+                    None,
+                )
+
+    def test_del_media_content_rejects_traversal(self):
+        for path in self._FILENAME_TRAVERSALS:
+            with self.subTest(path=path):
+                self._assert_raises_path_traversal(
+                    mediafiles.del_media_content,
+                    self._CAMERA_CONFIG,
+                    path,
+                    'picture',
+                )
+
+    def test_del_media_group_rejects_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                self._assert_raises_path_traversal(
+                    mediafiles.del_media_group,
+                    self._CAMERA_CONFIG,
+                    group,
+                    'picture',
+                )
 
 
 if __name__ == '__main__':

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests verifying that path traversal elements are rejected in remote module functions."""
+
+import unittest
+
+from motioneye import remote
+
+
+class TestRemotePathTraversal(unittest.IsolatedAsyncioTestCase):
+    """Tests verifying that path traversal elements are rejected in remote functions.
+
+    Each remote function performs its path traversal check synchronously before
+    any network I/O, so awaiting the coroutine raises immediately.
+    """
+
+    _LOCAL_CONFIG = {
+        '@proto': 'mjpeg',
+        '@host': '127.0.0.1',
+        '@port': 8765,
+        '@username': '',
+        '@password': '',
+        '@path': '',
+        '@remote_camera_id': 1,
+    }
+
+    # Traversal inputs to test for filenames/paths and groups/prefixes.
+    _FILENAME_TRAVERSALS = [
+        '../etc/passwd',
+        '../../etc/passwd',
+        'subdir/../../../etc/passwd',
+        '../secret.jpg',
+    ]
+    _GROUP_TRAVERSALS = [
+        '..',
+        '../group',
+        'subdir/..',
+        'subdir/../../other',
+    ]
+    _PREFIX_TRAVERSALS = [
+        '..',
+        '../prefix',
+        'prefix/../..',
+    ]
+
+    def _assert_raises_path_traversal(self, exception):
+        self.assertIn('Path traversal', str(exception))
+
+    async def test_list_media_rejects_prefix_traversal(self):
+        for prefix in self._PREFIX_TRAVERSALS:
+            with self.subTest(prefix=prefix):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.list_media(
+                        self._LOCAL_CONFIG, 'picture', prefix=prefix
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_get_media_content_rejects_traversal(self):
+        for filename in self._FILENAME_TRAVERSALS:
+            with self.subTest(filename=filename):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.get_media_content(
+                        self._LOCAL_CONFIG, filename, 'picture'
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_make_zipped_content_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.make_zipped_content(
+                        self._LOCAL_CONFIG, 'picture', group
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_get_zipped_content_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.get_zipped_content(
+                        self._LOCAL_CONFIG, 'picture', 'key123', group
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_make_timelapse_movie_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.make_timelapse_movie(self._LOCAL_CONFIG, 2, 1, group)
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_check_timelapse_movie_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.check_timelapse_movie(self._LOCAL_CONFIG, group)
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_get_timelapse_movie_rejects_group_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.get_timelapse_movie(
+                        self._LOCAL_CONFIG, 'key123', group
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_get_media_preview_rejects_traversal(self):
+        for filename in self._FILENAME_TRAVERSALS:
+            with self.subTest(filename=filename):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.get_media_preview(
+                        self._LOCAL_CONFIG, filename, 'picture', None, None
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_del_media_content_rejects_traversal(self):
+        for filename in self._FILENAME_TRAVERSALS:
+            with self.subTest(filename=filename):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.del_media_content(
+                        self._LOCAL_CONFIG, filename, 'picture'
+                    )
+                self._assert_raises_path_traversal(ctx.exception)
+
+    async def test_del_media_group_rejects_traversal(self):
+        for group in self._GROUP_TRAVERSALS:
+            with self.subTest(group=group):
+                with self.assertRaises(Exception) as ctx:
+                    await remote.del_media_group(self._LOCAL_CONFIG, group, 'picture')
+                self._assert_raises_path_traversal(ctx.exception)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It is currently possible to traverse to paths outside of the camera data directory with a number of API requests. This commit prevents path traversal directly at the initial GET/POST API handler methods, as well as complements the restriction in the final media file methods invoked by the handlers, to assure also internal usage of those methods deny path traversal.

Add type definitions to function arguments, and use Pillow default BICUBIC resampling filter instead of BILINEAR for thumbnails: `Image.FILTER` throws some false positive mypy annotation, and indeed `Image.Resampling.FILTER` exists instead, but requires a certain Pillow version, while the other constants is still valid. BICUBIC anyway has the better quality/perfornance ratio, being a reasonable default, and the possibly raised processing time for a preview API request should be negligible.