### PR TITLE
enh(config): check and apply strict mode when reading config

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -302,11 +302,15 @@ def get_main(as_lines=False):
             raise
 
     if f and S_IMODE(stat(config_file_path).st_mode) != 0o600:
-        logging.warning(f'main config file {config_file_path} has insecure mode, applying 0600 ...')
+        logging.warning(
+            f'main config file {config_file_path} has insecure mode, applying 0600 ...'
+        )
         try:
             os.chmod(config_file_path, 0o600)
         except Exception as e:
-            logging.error(f'failed to chown 0600 main config file {config_file_path}: {e}')
+            logging.error(
+                f'failed to chown 0600 main config file {config_file_path}: {e}'
+            )
             raise
 
     if lines is None and f:
@@ -495,11 +499,15 @@ def get_camera(camera_id, as_lines=False):
         raise
 
     if S_IMODE(stat(camera_config_path).st_mode) != 0o600:
-        logging.warning(f'camera config file {camera_config_path} has insecure mode, applying 0600 ...')
+        logging.warning(
+            f'camera config file {camera_config_path} has insecure mode, applying 0600 ...'
+        )
         try:
             os.chmod(camera_config_path, 0o600)
         except Exception as e:
-            logging.error(f'failed to chown 0600 camera config file {camera_config_path}: {e}')
+            logging.error(
+                f'failed to chown 0600 camera config file {camera_config_path}: {e}'
+            )
             raise
 
     try:

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -22,8 +22,10 @@ import logging
 import os.path
 import subprocess
 from errno import EEXIST, ENOENT
+from os import stat
 from re import match, sub
 from shlex import split
+from stat import S_IMODE
 from urllib.parse import quote, urlunparse
 
 from tornado.ioloop import IOLoop
@@ -299,6 +301,14 @@ def get_main(as_lines=False):
 
             raise
 
+    if f and S_IMODE(stat(config_file_path).st_mode) != 0o600:
+        logging.warning(f'main config file {config_file_path} has insecure mode, applying 0600 ...')
+        try:
+            os.chmod(config_file_path, 0o600)
+        except Exception as e:
+            logging.error(f'failed to chown 0600 main config file {config_file_path}: {e}')
+            raise
+
     if lines is None and f:
         try:
             lines = [line[:-1] for line in f.readlines()]
@@ -483,6 +493,14 @@ def get_camera(camera_id, as_lines=False):
         logging.error(f'could not open camera config file: {str(e)}')
 
         raise
+
+    if S_IMODE(stat(camera_config_path).st_mode) != 0o600:
+        logging.warning(f'camera config file {camera_config_path} has insecure mode, applying 0600 ...')
+        try:
+            os.chmod(camera_config_path, 0o600)
+        except Exception as e:
+            logging.error(f'failed to chown 0600 camera config file {camera_config_path}: {e}')
+            raise
 
     try:
         lines = [line.strip() for line in f.readlines()]

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:879
+#: motioneye/config.py:897
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:883
+#: motioneye/config.py:901
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v"
 msgstr ""
 
-#: motioneye/config.py:888
+#: motioneye/config.py:906
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:893
+#: motioneye/config.py:911
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:898
+#: motioneye/config.py:916
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:897
+#: motioneye/config.py:905
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:901
+#: motioneye/config.py:909
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v"
 msgstr ""
 
-#: motioneye/config.py:906
+#: motioneye/config.py:914
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:911
+#: motioneye/config.py:919
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:916
+#: motioneye/config.py:924
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 


### PR DESCRIPTION
That way, user do not need to save/change the config for strict modes to be applied. And motionEye throws a warning on startup if the mode is insecure, changing it.

We might want to do that at a different place, like on motionEye startup, for all config files which follow the pattern (`motion.conf` and `camera-*.conf` in `conf_path`), to reduce stat calls during operation, and otherwise only when creating new configs. However, for now, this get/set_main/camera are the obvious functions to hook into.

```
Mar 10 23:32:18 VM-Trixie systemd[1]: Started motioneye.service - motionEye Server.
Mar 10 23:32:19 VM-Trixie meyectl[1387]: WARNING:root:main config file /etc/motioneye/motion.conf has insecure mode, applying 0600 ...
Mar 10 23:32:19 VM-Trixie meyectl[1387]: configure_logging cmd motioneye: False
Mar 10 23:32:19 VM-Trixie meyectl[1387]: configure logging to file: None
Mar 10 23:32:19 VM-Trixie meyectl[1387]:     INFO: hello! this is motionEye server 0.44.0b1
Mar 10 23:32:20 VM-Trixie meyectl[1387]:  WARNING: camera config file /etc/motioneye/camera-1.conf has insecure mode, applying 0600 ...
Mar 10 23:32:20 VM-Trixie meyectl[1387]:  WARNING: camera config file /etc/motioneye/camera-2.conf has insecure mode, applying 0600 ...
```
```console
root@VM-Trixie:/etc/motioneye# ls -l
total 24
-rw------- 1 motion motion 2436 Feb 16 22:21 camera-1.conf
-rw------- 1 motion motion 2278 Feb 16 22:25 camera-2.conf
-rw------- 1 motion motion  259 Feb 16 22:25 motion.conf
-rw-r--r-- 1 motion motion 3021 Mar 10 19:20 motioneye.conf
-rw-r--r-- 1 motion motion    5 Feb 16 22:21 tasks.pickle
-rw-r--r-- 1 motion motion  285 Feb 16 22:21 uploadservices.json
```

Now I see for `uploadservices.json` the same should apply. But for a future PR. We should release 0.44.0 rather soon to push the most urgent fixes.