### PR TITLE
Use Tornado's parse_cookie to correctly unquote cookie values

### DIFF
--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 
 from PIL import Image, ImageDraw
 from tornado.concurrent import Future
+from tornado.httputil import parse_cookie
 from tornado.ioloop import IOLoop
 
 from motioneye import settings
@@ -269,15 +270,9 @@ def parse_cookies(cookies_headers: list[str]) -> dict[str, str]:
     parsed: dict[str, str] = {}
 
     for cookie in cookies_headers:
-        parts = cookie.split(';')
-        for c in parts:
-            name, value = c.split('=', 1)
-            name = name.strip()
-            value = value.strip()
-
+        for name, value in parse_cookie(cookie).items():
             if name.lower() in _SPECIAL_COOKIE_NAMES:
                 continue
-
             parsed[name] = value
 
     return parsed


### PR DESCRIPTION
Replace manual cookie splitting in `parse_cookies()` with Tornado’s [parse_cookie()](https://www.tornadoweb.org/en/stable/_modules/tornado/httputil.html#parse_cookie) so quoted values are unquoted correctly.

This normalizes `monitor_info_1=""` to an empty string and prevents it from being re-escaped to `\"\"` in the frontend.

Fixes #3082

(To test this, you do not necessarily need a separate motionEye instance. You can simply add an existing camera again as a remote motionEye camera.)

I also noticed that the [wiki](https://github.com/motioneye-project/motioneye/wiki/Monitoring-Commands) mentions creating the script in `/data/etc/monitor_1`. Is this correct, or should this be `/etc/motioneye`?