### PR TITLE
ci: update_locales: fix frontend template generation

### DIFF
--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Generate frontend template
       run: |
-        find -name '*.js' ! -name '*.min.js' | xgettext --from-code=UTF-8 --no-wrap -o motioneye/locale/motioneye.js.pot -
+        find -name '*.js' ! -name '*.min.js' | xargs xgettext --from-code=UTF-8 --no-wrap -o motioneye/locale/motioneye.js.pot
         # Remove header: --omit-header enforces ASCII output, despite --from-code=UTF-8, breaking most of our Esperanto source language accent characters
         sed -i '/^# SOME DESCRIPTIVE TITLE.$/,/^$/d' motioneye/locale/motioneye.js.pot
 

--- a/motioneye/locale/motioneye.js.pot
+++ b/motioneye/locale/motioneye.js.pot
@@ -1,521 +1,10 @@
-#: motioneye/static/js/main.js:611
-msgid "specialaj signoj ne rajtas en pasvorto"
-msgstr ""
-
-#: motioneye/static/js/main.js:618
-msgid "use of colon (:) is not allowed in video streaming username"
-msgstr ""
-
-#: motioneye/static/js/main.js:629
-msgid "video streaming authentication mode must be Basic or Digest when admin-only access is enabled"
-msgstr ""
-
-#: motioneye/static/js/main.js:636 motioneye/static/js/main.js:647
-#: motioneye/static/js/main.js:706 motioneye/static/js/ui.js:397
-msgid "Ĉi tiu kampo estas deviga"
-msgstr ""
-
-#: motioneye/static/js/main.js:640
-msgid "specialaj signoj ne rajtas en la nomo de kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:652
-msgid "valoro devas esti multoblo de 8"
-msgstr ""
-
-#: motioneye/static/js/main.js:659
-msgid "specialaj signoj ne rajtas en radika voja nomo"
-msgstr ""
-
-#: motioneye/static/js/main.js:662
-msgid "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo"
-msgstr ""
-
-#: motioneye/static/js/main.js:669
-msgid "enigu validan retpoŝtadreson"
-msgstr ""
-
-#: motioneye/static/js/main.js:676
-msgid "enigu liston de koma apartaj validaj retpoŝtadresoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:683
-msgid "specialaj signoj ne rajtas en dosiernomo"
-msgstr ""
-
-#: motioneye/static/js/main.js:710
-msgid "enigu validan valoron"
-msgstr ""
-
-#: motioneye/static/js/main.js:872
-msgid "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \""
-msgstr ""
-
-#: motioneye/static/js/main.js:873
-msgid "\", ne nur tiuj alŝutitaj de motionEye!"
-msgstr ""
-
-#: motioneye/static/js/main.js:954
-msgid "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \""
-msgstr ""
-
-#: motioneye/static/js/main.js:955
-msgid "\", ne nur tiuj kreitaj de motionEye!"
-msgstr ""
-
-#: motioneye/static/js/main.js:1021
-msgid "Ne eblas redakti la maskon sen valida kameraa bildo!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2275
-msgid "Propra"
-msgstr ""
-
-#: motioneye/static/js/main.js:2313
-msgid "Propra dosierindiko"
-msgstr ""
-
-#: motioneye/static/js/main.js:2315
-msgid "Retan kunlokon"
-msgstr ""
-
-#: motioneye/static/js/main.js:2678
-msgid "Via retumilo ne efektivigas ĉi tiun funkcion!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2694
-msgid "Apliki"
-msgstr ""
-
-#: motioneye/static/js/main.js:2721 motioneye/static/js/main.js:3083
-#: motioneye/static/js/main.js:3139 motioneye/static/js/main.js:3214
-msgid "Certigu, ke ĉiuj agordaj opcioj validas!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2824
-msgid "Ĉi tio rekomencos la sistemon. Daŭrigi?"
-msgstr ""
-
-#: motioneye/static/js/main.js:2834
-msgid "Vere fermiti sistemon?"
-msgstr ""
-
-#: motioneye/static/js/main.js:2846
-msgid "Malŝaltita"
-msgstr ""
-
-#: motioneye/static/js/main.js:2861
-msgid "Ĉu vere restartigi ?"
-msgstr ""
-
-#: motioneye/static/js/main.js:2875
-msgid "La sistemo rekomencis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2895 motioneye/static/js/main.js:2928
-#: motioneye/static/js/main.js:3904
-msgid "Bonvolu apliki unue la modifitajn agordojn!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2900
-msgid "Neniu fotilo por forigi!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2906
-msgid "Ĉu forigi kameraon "
-msgstr ""
-
-#: motioneye/static/js/main.js:2934
-msgid "motionEye estas ĝisdatigita (aktuala versio: "
-msgstr ""
-
-#: motioneye/static/js/main.js:2937
-msgid "Nova versio havebla: "
-msgstr ""
-
-#: motioneye/static/js/main.js:2937
-msgid ". Ĝisdatigi?"
-msgstr ""
-
-#: motioneye/static/js/main.js:2945
-msgid "motionEye estis sukcese ĝisdatigita!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2955
-msgid "Ĝisdatigo malsukcesis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2966
-msgid "La ĝisdatiga procezo malsukcesis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:2985
-msgid "Rezerva dosiero"
-msgstr ""
-
-#: motioneye/static/js/main.js:2987
-msgid "La rezervan dosieron, kiun vi antaŭe elŝutis."
-msgstr ""
-
-#: motioneye/static/js/main.js:3016
-msgid "Restaŭrigi Agordon"
-msgstr ""
-
-#: motioneye/static/js/main.js:3028
-msgid "Restaŭriganta agordon ..."
-msgstr ""
-
-#: motioneye/static/js/main.js:3035
-msgid "La agordo restaŭrigis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3045 motioneye/static/js/main.js:3064
-msgid "Malsukcesis restaŭri la agordon!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3120
-msgid "Aliri la alŝutan servon malsukcesis: "
-msgstr ""
-
-#: motioneye/static/js/main.js:3123
-msgid "Aliri la alŝutan servon sukcesis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3160
-msgid "Sciiga retpoŝto fiaskis:"
-msgstr ""
-
-#: motioneye/static/js/main.js:3163
-msgid "Notification email succeeded!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3179
-msgid "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3195
-msgid "Sciiga Telegramo fiaskis:"
-msgstr ""
-
-#: motioneye/static/js/main.js:3198
-msgid "Sciiga Telegramo sukcesis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3234
-msgid "Aliro al retdividado fiaskis: "
-msgstr ""
-
-#: motioneye/static/js/main.js:3237
-msgid "Aliro al retdividado sukcesis!"
-msgstr ""
-
-#: motioneye/static/js/main.js:3261
-msgid "Ĉu vere forigi ĉi tiun dosieron?"
-msgstr ""
-
-#: motioneye/static/js/main.js:3285
-msgid "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?"
-msgstr ""
-
-#: motioneye/static/js/main.js:3288
-msgid "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?"
-msgstr ""
-
-#: motioneye/static/js/main.js:3293
-msgid "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?"
-msgstr ""
-
-#: motioneye/static/js/main.js:3296
-msgid "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?"
-msgstr ""
-
-#: motioneye/static/js/main.js:3402
-msgid "aldonadi kameraon..."
-msgstr ""
-
-#: motioneye/static/js/main.js:3627 motioneye/static/js/main.js:3926
-msgid "Uzantnomo"
-msgstr ""
-
-#: motioneye/static/js/main.js:3632 motioneye/static/js/main.js:3931
-msgid "Pasvorto"
-msgstr ""
-
-#: motioneye/static/js/main.js:3638
-msgid "Memoru min"
-msgstr ""
-
-#: motioneye/static/js/main.js:3656 motioneye/static/js/main.js:3662
-msgid "Ensaluti"
-msgstr ""
-
-#: motioneye/static/js/main.js:3659 motioneye/static/js/ui.js:736
-#: motioneye/static/js/ui.js:743
-msgid "Nuligi"
-msgstr ""
-
-#: motioneye/static/js/main.js:3701
-msgid "Vi abortis la filmeton."
-msgstr ""
-
-#: motioneye/static/js/main.js:3704
-msgid "Reto eraro okazis."
-msgstr ""
-
-#: motioneye/static/js/main.js:3707
-msgid "Malkodado-eraro aŭ neprogresinta funkcio."
-msgstr ""
-
-#: motioneye/static/js/main.js:3710
-msgid "Formato ne subtenata aŭ neatingebla/netaŭga por ludado."
-msgstr ""
-
-#: motioneye/static/js/main.js:3713
-msgid "Nekonata eraro okazis."
-msgstr ""
-
-#: motioneye/static/js/main.js:3716
-msgid "Eraro : "
-msgstr ""
-
-#: motioneye/static/js/main.js:3721
-msgid "antaŭa bildo"
-msgstr ""
-
-#: motioneye/static/js/main.js:3726
-msgid "ludi"
-msgstr ""
-
-#: motioneye/static/js/main.js:3729
-msgid "ludi * 5 kaj enĉenigi"
-msgstr ""
-
-#: motioneye/static/js/main.js:3734
-msgid "sekva bildo"
-msgstr ""
-
-#: motioneye/static/js/main.js:3857
-msgid "Fermi"
-msgstr ""
-
-#: motioneye/static/js/main.js:3858 motioneye/static/js/main.js:4417
-msgid "Elŝuti"
-msgstr ""
-
-#: motioneye/static/js/main.js:3866 motioneye/static/js/main.js:4420
-msgid "Forigi"
-msgstr ""
-
-#: motioneye/static/js/main.js:3910
-msgid "Kamerao tipo"
-msgstr ""
-
-#: motioneye/static/js/main.js:3912
-msgid "Loka V4L2-kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3913
-msgid "Loka MMAL-kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3914
-msgid "Reta kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3915
-msgid "Fora motionEye kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3916
-msgid "Simpla MJPEG-kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3918
-msgid "la speco de kamerao, kiun vi volas aldoni"
-msgstr ""
-
-#: motioneye/static/js/main.js:3921
-msgid "URL"
-msgstr ""
-
-#: motioneye/static/js/main.js:3922
-msgid "http://ekzemplo.com:8765/cams/..."
-msgstr ""
-
-#: motioneye/static/js/main.js:3923
-msgid "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)"
-msgstr ""
-
-#: motioneye/static/js/main.js:3927
-msgid "uzantnomo..."
-msgstr ""
-
-#: motioneye/static/js/main.js:3928
-msgid "la uzantnomo por la URL, se bezonata (ekz. administranto)"
-msgstr ""
-
-#: motioneye/static/js/main.js:3932
-msgid "pasvorto..."
-msgstr ""
-
-#: motioneye/static/js/main.js:3933
-msgid "la pasvorto por la URL, se bezonata"
-msgstr ""
-
-#: motioneye/static/js/main.js:3936
-msgid "Kamerao"
-msgstr ""
-
-#: motioneye/static/js/main.js:3938
-msgid "la kameraon, kiun vi volas aldoni"
-msgstr ""
-
-#: motioneye/static/js/main.js:3972
-msgid "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime."
-msgstr ""
-
-#: motioneye/static/js/main.js:3987
-msgid "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG."
-msgstr ""
-
-#: motioneye/static/js/main.js:3992
-msgid "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj."
-msgstr ""
-
-#: motioneye/static/js/main.js:4007
-msgid "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer."
-msgstr ""
-
-#: motioneye/static/js/main.js:4012
-msgid "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB."
-msgstr ""
-
-#: motioneye/static/js/main.js:4163
-msgid "Aldonadi kameraon..."
-msgstr ""
-
-#: motioneye/static/js/main.js:4235
-msgid "Grupo"
-msgstr ""
-
-#: motioneye/static/js/main.js:4239
-msgid "Inkluzivi foton prenitan ĉiun"
-msgstr ""
-
-#: motioneye/static/js/main.js:4242
-msgid "sekundo"
-msgstr ""
-
-#: motioneye/static/js/main.js:4243
-msgid "5 sekundoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4244
-msgid "10 sekundoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4245
-msgid "30 sekundoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4246
-msgid "minuto"
-msgstr ""
-
-#: motioneye/static/js/main.js:4247
-msgid "5 minutoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4248
-msgid "10 minutoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4249
-msgid "30 minutoj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4250
-msgid "horo"
-msgstr ""
-
-#: motioneye/static/js/main.js:4253
-msgid "Elektu la intervalon de tempo inter du elektitaj bildoj."
-msgstr ""
-
-#: motioneye/static/js/main.js:4256
-msgid "Filmo framfrekvenco"
-msgstr ""
-
-#: motioneye/static/js/main.js:4258
-msgid "Elektu kiom rapide vi volas ke la akselita video estu."
-msgstr ""
-
-#: motioneye/static/js/main.js:4267
-msgid "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!"
-msgstr ""
-
-#: motioneye/static/js/main.js:4284
-msgid "Krei akselita video"
-msgstr ""
-
-#: motioneye/static/js/main.js:4293
-msgid "Filmo kreanta en progreso..."
-msgstr ""
-
-#: motioneye/static/js/main.js:4544
-msgid "Zipitaj"
-msgstr ""
-
-#: motioneye/static/js/main.js:4553
-msgid "Akselita video"
-msgstr ""
-
-#: motioneye/static/js/main.js:4564
-msgid "Forigi ĉiujn"
-msgstr ""
-
-#: motioneye/static/js/main.js:4706
-msgid "Bildoj prenitaj de "
-msgstr ""
-
-#: motioneye/static/js/main.js:4709
-msgid "Filmoj registritaj de "
-msgstr ""
-
-#: motioneye/static/js/main.js:4777
-msgid "montru ĉi tiun fotilon plenekranan"
-msgstr ""
-
-#: motioneye/static/js/main.js:4778
-msgid "montri ĉiujn fotilojn"
-msgstr ""
-
-#: motioneye/static/js/main.js:4779
-msgid "montru nur ĉi tiun fotilon"
-msgstr ""
-
-#: motioneye/static/js/main.js:4780
-msgid "malfermaj bildoj retumilo"
-msgstr ""
-
-#: motioneye/static/js/main.js:4781
-msgid "malferma videoj retumilo"
-msgstr ""
-
-#: motioneye/static/js/main.js:4782
-msgid "agordi ĉi tiun kameraon"
-msgstr ""
-
-#: motioneye/static/js/main.js:4798
-msgid "preni instantaron"
-msgstr ""
-
-#: motioneye/static/js/main.js:5191
-msgid "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ..."
-msgstr ""
-
 #: motioneye/static/js/ui.js:361
 msgid "enter a valid value"
+msgstr ""
+
+#: motioneye/static/js/ui.js:397 motioneye/static/js/main.js:485
+#: motioneye/static/js/main.js:496 motioneye/static/js/main.js:555
+msgid "Ĉi tiu kampo estas deviga"
 msgstr ""
 
 #: motioneye/static/js/ui.js:420
@@ -562,8 +51,551 @@ msgstr ""
 msgid "Jes"
 msgstr ""
 
+#: motioneye/static/js/ui.js:736 motioneye/static/js/ui.js:743
+#: motioneye/static/js/main.js:3508
+msgid "Nuligi"
+msgstr ""
+
 #: motioneye/static/js/ui.js:744 motioneye/static/js/ui.js:749
 msgid "Bone"
+msgstr ""
+
+#: motioneye/static/js/main.js:389
+msgid "An error occurred. Refreshing is recommended."
+msgstr ""
+
+#: motioneye/static/js/main.js:460
+msgid "specialaj signoj ne rajtas en pasvorto"
+msgstr ""
+
+#: motioneye/static/js/main.js:467
+msgid "use of colon (:) is not allowed in video streaming username"
+msgstr ""
+
+#: motioneye/static/js/main.js:478
+msgid "video streaming authentication mode must be Basic or Digest when admin-only access is enabled"
+msgstr ""
+
+#: motioneye/static/js/main.js:489
+msgid "specialaj signoj ne rajtas en la nomo de kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:501
+msgid "valoro devas esti multoblo de 8"
+msgstr ""
+
+#: motioneye/static/js/main.js:508
+msgid "specialaj signoj ne rajtas en radika voja nomo"
+msgstr ""
+
+#: motioneye/static/js/main.js:511
+msgid "dosieroj ne povas esti kreitaj rekte en la radiko de via sistemo"
+msgstr ""
+
+#: motioneye/static/js/main.js:518
+msgid "enigu validan retpoŝtadreson"
+msgstr ""
+
+#: motioneye/static/js/main.js:525
+msgid "enigu liston de koma apartaj validaj retpoŝtadresoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:532
+msgid "specialaj signoj ne rajtas en dosiernomo"
+msgstr ""
+
+#: motioneye/static/js/main.js:559
+msgid "enigu validan valoron"
+msgstr ""
+
+#: motioneye/static/js/main.js:721
+msgid "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \""
+msgstr ""
+
+#: motioneye/static/js/main.js:722
+msgid "\", ne nur tiuj alŝutitaj de motionEye!"
+msgstr ""
+
+#: motioneye/static/js/main.js:803
+msgid "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \""
+msgstr ""
+
+#: motioneye/static/js/main.js:804
+msgid "\", ne nur tiuj kreitaj de motionEye!"
+msgstr ""
+
+#: motioneye/static/js/main.js:870
+msgid "Ne eblas redakti la maskon sen valida kameraa bildo!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2130
+msgid "Propra"
+msgstr ""
+
+#: motioneye/static/js/main.js:2168
+msgid "Propra dosierindiko"
+msgstr ""
+
+#: motioneye/static/js/main.js:2170
+msgid "Retan kunlokon"
+msgstr ""
+
+#: motioneye/static/js/main.js:2526
+msgid "Via retumilo ne efektivigas ĉi tiun funkcion!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2542
+msgid "Apliki"
+msgstr ""
+
+#: motioneye/static/js/main.js:2569 motioneye/static/js/main.js:2940
+#: motioneye/static/js/main.js:2996 motioneye/static/js/main.js:3071
+msgid "Certigu, ke ĉiuj agordaj opcioj validas!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2623
+msgid "Admin password updated. Please log in again."
+msgstr ""
+
+#: motioneye/static/js/main.js:2681
+msgid "Ĉi tio rekomencos la sistemon. Daŭrigi?"
+msgstr ""
+
+#: motioneye/static/js/main.js:2691
+msgid "Vere fermiti sistemon?"
+msgstr ""
+
+#: motioneye/static/js/main.js:2703
+msgid "Malŝaltita"
+msgstr ""
+
+#: motioneye/static/js/main.js:2718
+msgid "Ĉu vere restartigi ?"
+msgstr ""
+
+#: motioneye/static/js/main.js:2732
+msgid "La sistemo rekomencis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2752 motioneye/static/js/main.js:2785
+#: motioneye/static/js/main.js:3803
+msgid "Bonvolu apliki unue la modifitajn agordojn!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2757
+msgid "Neniu fotilo por forigi!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2763
+msgid "Ĉu forigi kameraon "
+msgstr ""
+
+#: motioneye/static/js/main.js:2791
+msgid "motionEye estas ĝisdatigita (aktuala versio: "
+msgstr ""
+
+#: motioneye/static/js/main.js:2794
+msgid "Nova versio havebla: "
+msgstr ""
+
+#: motioneye/static/js/main.js:2794
+msgid ". Ĝisdatigi?"
+msgstr ""
+
+#: motioneye/static/js/main.js:2802
+msgid "motionEye estis sukcese ĝisdatigita!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2812
+msgid "Ĝisdatigo malsukcesis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2823
+msgid "La ĝisdatiga procezo malsukcesis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2842
+msgid "Rezerva dosiero"
+msgstr ""
+
+#: motioneye/static/js/main.js:2844
+msgid "La rezervan dosieron, kiun vi antaŭe elŝutis."
+msgstr ""
+
+#: motioneye/static/js/main.js:2873
+msgid "Restaŭrigi Agordon"
+msgstr ""
+
+#: motioneye/static/js/main.js:2885
+msgid "Restaŭriganta agordon ..."
+msgstr ""
+
+#: motioneye/static/js/main.js:2892
+msgid "La agordo restaŭrigis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2902 motioneye/static/js/main.js:2921
+msgid "Malsukcesis restaŭri la agordon!"
+msgstr ""
+
+#: motioneye/static/js/main.js:2977
+msgid "Aliri la alŝutan servon malsukcesis: "
+msgstr ""
+
+#: motioneye/static/js/main.js:2980
+msgid "Aliri la alŝutan servon sukcesis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:3017
+msgid "Sciiga retpoŝto fiaskis:"
+msgstr ""
+
+#: motioneye/static/js/main.js:3020
+msgid "Notification email succeeded!"
+msgstr ""
+
+#: motioneye/static/js/main.js:3036
+msgid "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!"
+msgstr ""
+
+#: motioneye/static/js/main.js:3052
+msgid "Sciiga Telegramo fiaskis:"
+msgstr ""
+
+#: motioneye/static/js/main.js:3055
+msgid "Sciiga Telegramo sukcesis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:3091
+msgid "Aliro al retdividado fiaskis: "
+msgstr ""
+
+#: motioneye/static/js/main.js:3094
+msgid "Aliro al retdividado sukcesis!"
+msgstr ""
+
+#: motioneye/static/js/main.js:3118
+msgid "Ĉu vere forigi ĉi tiun dosieron?"
+msgstr ""
+
+#: motioneye/static/js/main.js:3142
+msgid "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?"
+msgstr ""
+
+#: motioneye/static/js/main.js:3145
+msgid "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?"
+msgstr ""
+
+#: motioneye/static/js/main.js:3150
+msgid "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?"
+msgstr ""
+
+#: motioneye/static/js/main.js:3153
+msgid "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?"
+msgstr ""
+
+#: motioneye/static/js/main.js:3259
+msgid "aldonadi kameraon..."
+msgstr ""
+
+#: motioneye/static/js/main.js:3484 motioneye/static/js/main.js:3825
+msgid "Uzantnomo"
+msgstr ""
+
+#: motioneye/static/js/main.js:3489 motioneye/static/js/main.js:3830
+msgid "Pasvorto"
+msgstr ""
+
+#: motioneye/static/js/main.js:3501
+msgid "Please login to continue."
+msgstr ""
+
+#: motioneye/static/js/main.js:3505 motioneye/static/js/main.js:3509
+msgid "Ensaluti"
+msgstr ""
+
+#: motioneye/static/js/main.js:3536
+msgid "Your account requires a password to be set. Please contact the administrator to set a password for your account."
+msgstr ""
+
+#: motioneye/static/js/main.js:3549
+msgid "Please set a password for your account."
+msgstr ""
+
+#: motioneye/static/js/main.js:3566
+msgid "Login failed."
+msgstr ""
+
+#: motioneye/static/js/main.js:3600
+msgid "Vi abortis la filmeton."
+msgstr ""
+
+#: motioneye/static/js/main.js:3603
+msgid "Reto eraro okazis."
+msgstr ""
+
+#: motioneye/static/js/main.js:3606
+msgid "Malkodado-eraro aŭ neprogresinta funkcio."
+msgstr ""
+
+#: motioneye/static/js/main.js:3609
+msgid "Formato ne subtenata aŭ neatingebla/netaŭga por ludado."
+msgstr ""
+
+#: motioneye/static/js/main.js:3612
+msgid "Nekonata eraro okazis."
+msgstr ""
+
+#: motioneye/static/js/main.js:3615
+msgid "Eraro : "
+msgstr ""
+
+#: motioneye/static/js/main.js:3620
+msgid "antaŭa bildo"
+msgstr ""
+
+#: motioneye/static/js/main.js:3625
+msgid "ludi"
+msgstr ""
+
+#: motioneye/static/js/main.js:3628
+msgid "ludi * 5 kaj enĉenigi"
+msgstr ""
+
+#: motioneye/static/js/main.js:3633
+msgid "sekva bildo"
+msgstr ""
+
+#: motioneye/static/js/main.js:3756
+msgid "Fermi"
+msgstr ""
+
+#: motioneye/static/js/main.js:3757 motioneye/static/js/main.js:4318
+msgid "Elŝuti"
+msgstr ""
+
+#: motioneye/static/js/main.js:3765 motioneye/static/js/main.js:4321
+msgid "Forigi"
+msgstr ""
+
+#: motioneye/static/js/main.js:3809
+msgid "Kamerao tipo"
+msgstr ""
+
+#: motioneye/static/js/main.js:3811
+msgid "Loka V4L2-kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3812
+msgid "Loka MMAL-kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3813
+msgid "Reta kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3814
+msgid "Fora motionEye kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3815
+msgid "Simpla MJPEG-kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3817
+msgid "la speco de kamerao, kiun vi volas aldoni"
+msgstr ""
+
+#: motioneye/static/js/main.js:3820
+msgid "URL"
+msgstr ""
+
+#: motioneye/static/js/main.js:3821
+msgid "http://ekzemplo.com:8765/cams/..."
+msgstr ""
+
+#: motioneye/static/js/main.js:3822
+msgid "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)"
+msgstr ""
+
+#: motioneye/static/js/main.js:3826
+msgid "uzantnomo..."
+msgstr ""
+
+#: motioneye/static/js/main.js:3827
+msgid "la uzantnomo por la URL, se bezonata (ekz. administranto)"
+msgstr ""
+
+#: motioneye/static/js/main.js:3831
+msgid "pasvorto..."
+msgstr ""
+
+#: motioneye/static/js/main.js:3832
+msgid "la pasvorto por la URL, se bezonata"
+msgstr ""
+
+#: motioneye/static/js/main.js:3835
+msgid "Remote Secret"
+msgstr ""
+
+#: motioneye/static/js/main.js:3836
+msgid "remote secret..."
+msgstr ""
+
+#: motioneye/static/js/main.js:3837
+msgid "the client secret of the remote motionEye server. Find this value in the Client Secret field of the remote server's general settings."
+msgstr ""
+
+#: motioneye/static/js/main.js:3840
+msgid "Kamerao"
+msgstr ""
+
+#: motioneye/static/js/main.js:3842
+msgid "la kameraon, kiun vi volas aldoni"
+msgstr ""
+
+#: motioneye/static/js/main.js:3876
+msgid "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime."
+msgstr ""
+
+#: motioneye/static/js/main.js:3889
+msgid "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG."
+msgstr ""
+
+#: motioneye/static/js/main.js:3894
+msgid "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj."
+msgstr ""
+
+#: motioneye/static/js/main.js:3907
+msgid "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer."
+msgstr ""
+
+#: motioneye/static/js/main.js:3912
+msgid "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB."
+msgstr ""
+
+#: motioneye/static/js/main.js:4065
+msgid "Aldonadi kameraon..."
+msgstr ""
+
+#: motioneye/static/js/main.js:4136
+msgid "Grupo"
+msgstr ""
+
+#: motioneye/static/js/main.js:4140
+msgid "Inkluzivi foton prenitan ĉiun"
+msgstr ""
+
+#: motioneye/static/js/main.js:4143
+msgid "sekundo"
+msgstr ""
+
+#: motioneye/static/js/main.js:4144
+msgid "5 sekundoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4145
+msgid "10 sekundoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4146
+msgid "30 sekundoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4147
+msgid "minuto"
+msgstr ""
+
+#: motioneye/static/js/main.js:4148
+msgid "5 minutoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4149
+msgid "10 minutoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4150
+msgid "30 minutoj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4151
+msgid "horo"
+msgstr ""
+
+#: motioneye/static/js/main.js:4154
+msgid "Elektu la intervalon de tempo inter du elektitaj bildoj."
+msgstr ""
+
+#: motioneye/static/js/main.js:4157
+msgid "Filmo framfrekvenco"
+msgstr ""
+
+#: motioneye/static/js/main.js:4159
+msgid "Elektu kiom rapide vi volas ke la akselita video estu."
+msgstr ""
+
+#: motioneye/static/js/main.js:4168
+msgid "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!"
+msgstr ""
+
+#: motioneye/static/js/main.js:4185
+msgid "Krei akselita video"
+msgstr ""
+
+#: motioneye/static/js/main.js:4194
+msgid "Filmo kreanta en progreso..."
+msgstr ""
+
+#: motioneye/static/js/main.js:4445
+msgid "Zipitaj"
+msgstr ""
+
+#: motioneye/static/js/main.js:4454
+msgid "Akselita video"
+msgstr ""
+
+#: motioneye/static/js/main.js:4465
+msgid "Forigi ĉiujn"
+msgstr ""
+
+#: motioneye/static/js/main.js:4607
+msgid "Bildoj prenitaj de "
+msgstr ""
+
+#: motioneye/static/js/main.js:4610
+msgid "Filmoj registritaj de "
+msgstr ""
+
+#: motioneye/static/js/main.js:4678
+msgid "montru ĉi tiun fotilon plenekranan"
+msgstr ""
+
+#: motioneye/static/js/main.js:4679
+msgid "montri ĉiujn fotilojn"
+msgstr ""
+
+#: motioneye/static/js/main.js:4680
+msgid "montru nur ĉi tiun fotilon"
+msgstr ""
+
+#: motioneye/static/js/main.js:4681
+msgid "malfermaj bildoj retumilo"
+msgstr ""
+
+#: motioneye/static/js/main.js:4682
+msgid "malferma videoj retumilo"
+msgstr ""
+
+#: motioneye/static/js/main.js:4683
+msgid "agordi ĉi tiun kameraon"
+msgstr ""
+
+#: motioneye/static/js/main.js:4699
+msgid "preni instantaron"
+msgstr ""
+
+#: motioneye/static/js/main.js:5092
+msgid "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ..."
 msgstr ""
 
 #: l10n/v4l2.js:4


### PR DESCRIPTION
xgettext guesses the input (code) language from the input file extensions. But as use STDIN, hence no extension to guess from, in which case it falls back to C and does not find any string.

Define JavaScript as input code language explicitly.