### PR TITLE
enh(config): limit backup/restore to specific files

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -14,13 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import collections
-import datetime
-import glob
 import logging
 import os.path
 import subprocess
+import tarfile
+from collections import OrderedDict
+from datetime import timedelta
 from errno import EEXIST, ENOENT
+from fnmatch import fnmatch
+from glob import glob
+from io import BytesIO
 from os import stat
 from re import match, sub
 from secrets import token_hex
@@ -2094,64 +2097,44 @@ def invalidate_monitor_commands():
     _monitor_command_cache.clear()
 
 
-def backup():
+def backup() -> bytes | None:
     logging.debug('generating config backup file')
 
-    if len(os.listdir(settings.CONF_PATH)) > 100:
-        logging.debug(
-            f'config path "{settings.CONF_PATH}" appears to be a system-wide config directory, performing a selective backup'
-        )
-
-        cmd = ['tar', 'zc', 'motion.conf']
-        cmd += list(
-            map(
-                os.path.basename,
-                glob.glob(os.path.join(settings.CONF_PATH, 'camera-*.conf')),
-            )
-        )
-        try:
-            content = utils.call_subprocess(cmd, cwd=settings.CONF_PATH, encoding=None)
-            logging.debug(f'backup file created ({len(content)} bytes)')
-
-            return content
-
-        except Exception as e:
-            logging.error(f'backup failed: {e}', exc_info=True)
-
-            return None
-
-    else:
-        logging.debug(
-            f'config path "{settings.CONF_PATH}" appears to be a motion-specific config directory, performing a full backup'
-        )
-
-        try:
-            content = utils.call_subprocess(
-                ['tar', 'zc', '.'], cwd=settings.CONF_PATH, encoding=None
-            )
-            logging.debug(f'backup file created ({len(content)} bytes)')
-
-            return content
-
-        except Exception as e:
-            logging.error(f'backup failed: {e}', exc_info=True)
-
-            return None
-
-
-def restore(content):
-    logging.info('restoring config from backup file')
-
-    cmd = ['tar', 'zxC', settings.CONF_PATH]
+    files = [
+        f
+        for p in ('motion.conf', 'camera-*.conf', 'prefs.json')
+        for f in glob(os.path.join(settings.CONF_PATH, p))
+    ]
 
     try:
-        p = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        msg = p.communicate(content)[0]
-        if msg:
-            logging.error(f'failed to restore configuration: {msg}')
-            return False
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode='w:gz') as tf:
+            for f in files:
+                tf.add(f, arcname=os.path.basename(f))
+
+        logging.debug(f'backup file created ({buf.tell()} bytes)')
+
+        return buf.getvalue()
+
+    except Exception as e:
+        logging.error(f'backup failed: {e}', exc_info=True)
+
+        return None
+
+
+def restore(content: bytes) -> dict | None:
+    logging.info('restoring config from backup file')
+
+    patterns = ['motion.conf', 'camera-*.conf', 'prefs.json']
+
+    try:
+        with tarfile.open(fileobj=BytesIO(content)) as tf:
+            members = [
+                m
+                for m in tf.getmembers()
+                if any(fnmatch(m.name.lstrip('./'), p) for p in patterns)
+            ]
+            tf.extractall(settings.CONF_PATH, members=members)  # nosec B202
 
         logging.debug('configuration restored successfully')
 
@@ -2161,7 +2144,7 @@ def restore(content):
                 PowerControl.reboot()
 
             io_loop = IOLoop.current()
-            io_loop.add_timeout(datetime.timedelta(seconds=2), later)
+            io_loop.add_timeout(timedelta(seconds=2), later)
 
         else:
             invalidate()
@@ -2227,7 +2210,7 @@ def _conf_to_dict(lines, list_names=None, no_convert=None):
     if no_convert is None:
         no_convert = []
 
-    data = collections.OrderedDict()
+    data = OrderedDict()
 
     for line in lines:
         line = line.strip()
@@ -2267,7 +2250,7 @@ def _dict_to_conf(lines, data, list_names=None):
         list_names = []
 
     conf_lines = []
-    remaining = collections.OrderedDict(data)
+    remaining = OrderedDict(data)
     processed = set()
 
     # parse existing lines and replace the values
@@ -2511,7 +2494,7 @@ def get_additional_structure(camera, separators=False):
         )
 
         # gather sections
-        sections = collections.OrderedDict()
+        sections = OrderedDict()
         for func in _additional_section_funcs:
             result = func()
             if not result:
@@ -2528,7 +2511,7 @@ def get_additional_structure(camera, separators=False):
 
             logging.debug(f"additional config section: {result['name']}")
 
-        configs = collections.OrderedDict()
+        configs = OrderedDict()
         for func in _additional_config_funcs:
             result = func()
             if not result:
@@ -2561,7 +2544,7 @@ def _get_additional_config(data, camera_id=None):
 
     sections, configs = get_additional_structure(camera=bool(camera_id))
     get_funcs = {c.get('get') for c in list(configs.values()) if c.get('get')}
-    get_func_values = collections.OrderedDict((f, f(*args)) for f in get_funcs)
+    get_func_values = OrderedDict((f, f(*args)) for f in get_funcs)
 
     for name, section in list(sections.items()):
         if not section.get('get'):
@@ -2589,7 +2572,7 @@ def _set_additional_config(data, camera_id=None):
 
     sections, configs = get_additional_structure(camera=bool(camera_id))
 
-    set_func_values = collections.OrderedDict()
+    set_func_values = OrderedDict()
     for name, section in list(sections.items()):
         if not section.get('set'):
             continue

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -2102,7 +2102,7 @@ def backup() -> bytes | None:
 
     files = [
         f
-        for p in ('motion.conf', 'camera-*.conf', 'prefs.json')
+        for p in ('motion.conf', 'camera-*.conf', 'mask_*.pgm', 'prefs.json')
         for f in glob(os.path.join(settings.CONF_PATH, p))
     ]
 
@@ -2125,7 +2125,7 @@ def backup() -> bytes | None:
 def restore(content: bytes) -> dict | None:
     logging.info('restoring config from backup file')
 
-    patterns = ['motion.conf', 'camera-*.conf', 'prefs.json']
+    patterns = ['motion.conf', 'camera-*.conf', 'mask_*.pgm', 'prefs.json']
 
     try:
         with tarfile.open(fileobj=BytesIO(content)) as tf:

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:944
+#: motioneye/config.py:947
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:948
+#: motioneye/config.py:951
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v"
 msgstr ""
 
-#: motioneye/config.py:953
+#: motioneye/config.py:956
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:958
+#: motioneye/config.py:961
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:963
+#: motioneye/config.py:966
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,8 @@ from motioneye import config, settings
 class TestBackup(unittest.TestCase):
     """Tests for config.backup()."""
 
+    conf_dir: str
+
     @classmethod
     def setUpClass(cls):
         cls.conf_dir = mkdtemp()
@@ -107,6 +109,8 @@ class TestBackup(unittest.TestCase):
 class TestRestore(unittest.TestCase):
     """Tests for config.restore()."""
 
+    conf_dir: str
+
     @classmethod
     def setUpClass(cls):
         cls.conf_dir = mkdtemp()
@@ -137,16 +141,13 @@ class TestRestore(unittest.TestCase):
                 tf.addfile(info, BytesIO(data))
         return buf.getvalue()
 
-    def _conf_files(self) -> list:
-        return os.listdir(self.conf_dir)
-
     def test_restore_extracts_motion_conf(self):
         content = b'[motion]\ndaemon = on\n'
         tarball = self._make_tarball({'motion.conf': content})
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('motion.conf', self._conf_files())
+        self.assertIn('motion.conf', os.listdir(self.conf_dir))
         with open(os.path.join(self.conf_dir, 'motion.conf'), 'rb') as f:
             self.assertEqual(f.read(), content)
 
@@ -158,7 +159,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = self._conf_files()
+        files = os.listdir(self.conf_dir)
         self.assertIn('camera-1.conf', files)
         self.assertIn('camera-42.conf', files)
 
@@ -167,7 +168,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('prefs.json', self._conf_files())
+        self.assertIn('prefs.json', os.listdir(self.conf_dir))
 
     def test_restore_ignores_non_matching_files(self):
         tarball = self._make_tarball({
@@ -179,7 +180,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = self._conf_files()
+        files = os.listdir(self.conf_dir)
         self.assertIn('motion.conf', files)
         self.assertNotIn('uploadservices.json', files)
         self.assertNotIn('secrets.json', files)
@@ -191,7 +192,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('motion.conf', self._conf_files())
+        self.assertIn('motion.conf', os.listdir(self.conf_dir))
 
     def test_restore_returns_reboot_false(self):
         tarball = self._make_tarball({'motion.conf': b'[motion]\n'})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tarfile
+import unittest
+from io import BytesIO
+from shutil import rmtree
+from tempfile import mkdtemp
+from unittest import mock
+
+from motioneye import config, settings
+
+
+class TestBackup(unittest.TestCase):
+    """Tests for config.backup()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.conf_dir = mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.conf_dir)
+
+    def setUp(self):
+        # Clean the config dir before each test
+        for name in os.listdir(self.conf_dir):
+            os.remove(os.path.join(self.conf_dir, name))
+
+    def _write(self, filename, content=b''):
+        path = os.path.join(self.conf_dir, filename)
+        with open(path, 'wb') as f:
+            f.write(content)
+
+    def _get_tarball_names(self, data: bytes) -> list:
+        with tarfile.open(fileobj=BytesIO(data)) as tf:
+            return tf.getnames()
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_includes_motion_conf(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        self._write('motion.conf', b'[motion]\n')
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        self.assertIn('motion.conf', self._get_tarball_names(data))
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_includes_camera_confs(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        self._write('camera-1.conf', b'camera 1\n')
+        self._write('camera-2.conf', b'camera 2\n')
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        names = self._get_tarball_names(data)
+        self.assertIn('camera-1.conf', names)
+        self.assertIn('camera-2.conf', names)
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_includes_prefs_json(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        self._write('prefs.json', b'{}')
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        self.assertIn('prefs.json', self._get_tarball_names(data))
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_excludes_other_files(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        self._write('motion.conf', b'[motion]\n')
+        self._write('uploadservices.json', b'{}')
+        self._write('secrets.json', b'{}')
+        self._write('motioneye.conf', b'secret=password\n')
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        names = self._get_tarball_names(data)
+        self.assertNotIn('uploadservices.json', names)
+        self.assertNotIn('secrets.json', names)
+        self.assertNotIn('motioneye.conf', names)
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_omits_missing_prefs_json(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        self._write('motion.conf', b'[motion]\n')
+        # prefs.json intentionally not created
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        names = self._get_tarball_names(data)
+        self.assertNotIn('prefs.json', names)
+
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_backup_empty_dir_returns_empty_tarball(self, mock_conf_path):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        self.assertEqual(self._get_tarball_names(data), [])
+
+
+class TestRestore(unittest.TestCase):
+    """Tests for config.restore()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.conf_dir = mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.conf_dir)
+
+    def setUp(self):
+        # Clean the config dir before each test
+        for name in os.listdir(self.conf_dir):
+            os.remove(os.path.join(self.conf_dir, name))
+
+    def _make_tarball(self, files: dict) -> bytes:
+        """Create an in-memory .tar.gz with the given filename->content mapping."""
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode='w:gz') as tf:
+            for name, content in files.items():
+                data = content if isinstance(content, bytes) else content.encode()
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tf.addfile(info, BytesIO(data))
+        return buf.getvalue()
+
+    def _conf_files(self) -> list:
+        return os.listdir(self.conf_dir)
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_extracts_motion_conf(self, mock_conf_path, mock_invalidate):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        content = b'[motion]\ndaemon = on\n'
+        tarball = self._make_tarball({'motion.conf': content})
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        self.assertIn('motion.conf', self._conf_files())
+        with open(os.path.join(self.conf_dir, 'motion.conf'), 'rb') as f:
+            self.assertEqual(f.read(), content)
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_extracts_camera_confs(self, mock_conf_path, mock_invalidate):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        tarball = self._make_tarball({
+            'camera-1.conf': b'camera 1',
+            'camera-42.conf': b'camera 42',
+        })
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = self._conf_files()
+        self.assertIn('camera-1.conf', files)
+        self.assertIn('camera-42.conf', files)
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_extracts_prefs_json(self, mock_conf_path, mock_invalidate):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        tarball = self._make_tarball({'prefs.json': b'{}'})
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        self.assertIn('prefs.json', self._conf_files())
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_ignores_non_matching_files(self, mock_conf_path, mock_invalidate):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        tarball = self._make_tarball({
+            'motion.conf': b'[motion]\n',
+            'uploadservices.json': b'{}',
+            'secrets.json': b'{}',
+            'motioneye.conf': b'secret=password\n',
+        })
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = self._conf_files()
+        self.assertIn('motion.conf', files)
+        self.assertNotIn('uploadservices.json', files)
+        self.assertNotIn('secrets.json', files)
+        self.assertNotIn('motioneye.conf', files)
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_accepts_dot_slash_prefix(self, mock_conf_path, mock_invalidate):
+        """Tarball entries prefixed with ./ (e.g. from GNU tar) should still be accepted."""
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        tarball = self._make_tarball({'./motion.conf': b'[motion]\n'})
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        self.assertIn('motion.conf', self._conf_files())
+
+    @mock.patch('motioneye.config.invalidate')
+    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
+    @mock.patch.object(settings, 'CONF_PATH')
+    def test_restore_returns_reboot_false(self, mock_conf_path, mock_invalidate):
+        mock_conf_path.__str__ = lambda _: self.conf_dir
+        settings.CONF_PATH = self.conf_dir
+        tarball = self._make_tarball({'motion.conf': b'[motion]\n'})
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, {'reboot': False})
+
+    def test_restore_invalid_data_returns_none(self):
+        result = config.restore(b'not a tarball')
+        self.assertIsNone(result)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,9 +31,12 @@ class TestBackup(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.conf_dir = mkdtemp()
+        cls._orig_conf_path = settings.CONF_PATH
+        settings.CONF_PATH = cls.conf_dir
 
     @classmethod
     def tearDownClass(cls):
+        settings.CONF_PATH = cls._orig_conf_path
         rmtree(cls.conf_dir)
 
     def setUp(self):
@@ -50,20 +53,14 @@ class TestBackup(unittest.TestCase):
         with tarfile.open(fileobj=BytesIO(data)) as tf:
             return tf.getnames()
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_includes_motion_conf(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_backup_includes_motion_conf(self):
         self._write('motion.conf', b'[motion]\n')
 
         data = config.backup()
         self.assertIsNotNone(data)
         self.assertIn('motion.conf', self._get_tarball_names(data))
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_includes_camera_confs(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_backup_includes_camera_confs(self):
         self._write('camera-1.conf', b'camera 1\n')
         self._write('camera-2.conf', b'camera 2\n')
 
@@ -73,20 +70,14 @@ class TestBackup(unittest.TestCase):
         self.assertIn('camera-1.conf', names)
         self.assertIn('camera-2.conf', names)
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_includes_prefs_json(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_backup_includes_prefs_json(self):
         self._write('prefs.json', b'{}')
 
         data = config.backup()
         self.assertIsNotNone(data)
         self.assertIn('prefs.json', self._get_tarball_names(data))
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_excludes_other_files(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_backup_excludes_other_files(self):
         self._write('motion.conf', b'[motion]\n')
         self._write('uploadservices.json', b'{}')
         self._write('secrets.json', b'{}')
@@ -99,10 +90,7 @@ class TestBackup(unittest.TestCase):
         self.assertNotIn('secrets.json', names)
         self.assertNotIn('motioneye.conf', names)
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_omits_missing_prefs_json(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_backup_omits_missing_prefs_json(self):
         self._write('motion.conf', b'[motion]\n')
         # prefs.json intentionally not created
 
@@ -111,11 +99,7 @@ class TestBackup(unittest.TestCase):
         names = self._get_tarball_names(data)
         self.assertNotIn('prefs.json', names)
 
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_backup_empty_dir_returns_empty_tarball(self, mock_conf_path):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
-
+    def test_backup_empty_dir_returns_empty_tarball(self):
         data = config.backup()
         self.assertIsNotNone(data)
         self.assertEqual(self._get_tarball_names(data), [])
@@ -127,15 +111,26 @@ class TestRestore(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.conf_dir = mkdtemp()
+        cls._orig_conf_path = settings.CONF_PATH
+        cls._orig_enable_reboot = settings.ENABLE_REBOOT
+        settings.CONF_PATH = cls.conf_dir
+        settings.ENABLE_REBOOT = False
 
     @classmethod
     def tearDownClass(cls):
+        settings.CONF_PATH = cls._orig_conf_path
+        settings.ENABLE_REBOOT = cls._orig_enable_reboot
         rmtree(cls.conf_dir)
 
     def setUp(self):
         # Clean the config dir before each test
         for name in os.listdir(self.conf_dir):
             os.remove(os.path.join(self.conf_dir, name))
+        self._invalidate_patch = mock.patch('motioneye.config.invalidate')
+        self._invalidate_patch.start()
+
+    def tearDown(self):
+        self._invalidate_patch.stop()
 
     def _make_tarball(self, files: dict) -> bytes:
         """Create an in-memory .tar.gz with the given filename->content mapping."""
@@ -151,12 +146,7 @@ class TestRestore(unittest.TestCase):
     def _conf_files(self) -> list:
         return os.listdir(self.conf_dir)
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_extracts_motion_conf(self, mock_conf_path, mock_invalidate):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_restore_extracts_motion_conf(self):
         content = b'[motion]\ndaemon = on\n'
         tarball = self._make_tarball({'motion.conf': content})
 
@@ -166,12 +156,7 @@ class TestRestore(unittest.TestCase):
         with open(os.path.join(self.conf_dir, 'motion.conf'), 'rb') as f:
             self.assertEqual(f.read(), content)
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_extracts_camera_confs(self, mock_conf_path, mock_invalidate):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_restore_extracts_camera_confs(self):
         tarball = self._make_tarball({
             'camera-1.conf': b'camera 1',
             'camera-42.conf': b'camera 42',
@@ -183,24 +168,14 @@ class TestRestore(unittest.TestCase):
         self.assertIn('camera-1.conf', files)
         self.assertIn('camera-42.conf', files)
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_extracts_prefs_json(self, mock_conf_path, mock_invalidate):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_restore_extracts_prefs_json(self):
         tarball = self._make_tarball({'prefs.json': b'{}'})
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
         self.assertIn('prefs.json', self._conf_files())
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_ignores_non_matching_files(self, mock_conf_path, mock_invalidate):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_restore_ignores_non_matching_files(self):
         tarball = self._make_tarball({
             'motion.conf': b'[motion]\n',
             'uploadservices.json': b'{}',
@@ -216,25 +191,15 @@ class TestRestore(unittest.TestCase):
         self.assertNotIn('secrets.json', files)
         self.assertNotIn('motioneye.conf', files)
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_accepts_dot_slash_prefix(self, mock_conf_path, mock_invalidate):
+    def test_restore_accepts_dot_slash_prefix(self):
         """Tarball entries prefixed with ./ (e.g. from GNU tar) should still be accepted."""
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
         tarball = self._make_tarball({'./motion.conf': b'[motion]\n'})
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
         self.assertIn('motion.conf', self._conf_files())
 
-    @mock.patch('motioneye.config.invalidate')
-    @mock.patch.object(settings, 'ENABLE_REBOOT', False)
-    @mock.patch.object(settings, 'CONF_PATH')
-    def test_restore_returns_reboot_false(self, mock_conf_path, mock_invalidate):
-        mock_conf_path.__str__ = lambda _: self.conf_dir
-        settings.CONF_PATH = self.conf_dir
+    def test_restore_returns_reboot_false(self):
         tarball = self._make_tarball({'motion.conf': b'[motion]\n'})
 
         result = config.restore(tarball)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,10 +171,12 @@ class TestRestore(unittest.TestCase):
             self.assertEqual(f.read(), content)
 
     def test_restore_extracts_camera_confs(self):
-        tarball = self._make_tarball({
-            'camera-1.conf': b'camera 1',
-            'camera-42.conf': b'camera 42',
-        })
+        tarball = self._make_tarball(
+            {
+                'camera-1.conf': b'camera 1',
+                'camera-42.conf': b'camera 42',
+            }
+        )
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
@@ -183,10 +185,12 @@ class TestRestore(unittest.TestCase):
         self.assertIn('camera-42.conf', files)
 
     def test_restore_extracts_mask_files(self):
-        tarball = self._make_tarball({
-            'mask_1.pgm': b'P5\n',
-            'mask_2.pgm': b'P5\n',
-        })
+        tarball = self._make_tarball(
+            {
+                'mask_1.pgm': b'P5\n',
+                'mask_2.pgm': b'P5\n',
+            }
+        )
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
@@ -202,12 +206,14 @@ class TestRestore(unittest.TestCase):
         self.assertIn('prefs.json', os.listdir(self.conf_dir))
 
     def test_restore_ignores_non_matching_files(self):
-        tarball = self._make_tarball({
-            'motion.conf': b'[motion]\n',
-            'uploadservices.json': b'{}',
-            'secrets.json': b'{}',
-            'motioneye.conf': b'secret=password\n',
-        })
+        tarball = self._make_tarball(
+            {
+                'motion.conf': b'[motion]\n',
+                'uploadservices.json': b'{}',
+                'secrets.json': b'{}',
+                'motioneye.conf': b'secret=password\n',
+            }
+        )
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,16 @@ class TestBackup(unittest.TestCase):
         self.assertIn('camera-1.conf', names)
         self.assertIn('camera-2.conf', names)
 
+    def test_backup_includes_mask_files(self):
+        self._write('mask_1.pgm', b'P5\n')
+        self._write('mask_2.pgm', b'P5\n')
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        names = self._get_tarball_names(data)
+        self.assertIn('mask_1.pgm', names)
+        self.assertIn('mask_2.pgm', names)
+
     def test_backup_includes_prefs_json(self):
         self._write('prefs.json', b'{}')
 
@@ -90,6 +100,15 @@ class TestBackup(unittest.TestCase):
         self.assertNotIn('uploadservices.json', names)
         self.assertNotIn('secrets.json', names)
         self.assertNotIn('motioneye.conf', names)
+
+    def test_backup_omits_missing_mask_files(self):
+        self._write('motion.conf', b'[motion]\n')
+        # mask_*.pgm intentionally not created
+
+        data = config.backup()
+        self.assertIsNotNone(data)
+        names = self._get_tarball_names(data)
+        self.assertFalse(any(n.startswith('mask_') for n in names))
 
     def test_backup_omits_missing_prefs_json(self):
         self._write('motion.conf', b'[motion]\n')
@@ -162,6 +181,18 @@ class TestRestore(unittest.TestCase):
         files = os.listdir(self.conf_dir)
         self.assertIn('camera-1.conf', files)
         self.assertIn('camera-42.conf', files)
+
+    def test_restore_extracts_mask_files(self):
+        tarball = self._make_tarball({
+            'mask_1.pgm': b'P5\n',
+            'mask_2.pgm': b'P5\n',
+        })
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = os.listdir(self.conf_dir)
+        self.assertIn('mask_1.pgm', files)
+        self.assertIn('mask_2.pgm', files)
 
     def test_restore_extracts_prefs_json(self):
         tarball = self._make_tarball({'prefs.json': b'{}'})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,6 @@ import unittest
 from io import BytesIO
 from shutil import rmtree
 from tempfile import mkdtemp
-from unittest import mock
 
 from motioneye import config, settings
 
@@ -126,11 +125,6 @@ class TestRestore(unittest.TestCase):
         # Clean the config dir before each test
         for name in os.listdir(self.conf_dir):
             os.remove(os.path.join(self.conf_dir, name))
-        self._invalidate_patch = mock.patch('motioneye.config.invalidate')
-        self._invalidate_patch.start()
-
-    def tearDown(self):
-        self._invalidate_patch.stop()
 
     def _make_tarball(self, files: dict) -> bytes:
         """Create an in-memory .tar.gz with the given filename->content mapping."""


### PR DESCRIPTION
Backup and restore only those files which are actually generated by motionEye, and reasonable to restore: `motion.conf`, `camera-*.conf`, and `prefs.json`. `uploadservices.json` contains mostly redundant overridden info (dedicated cleanup needed), and refresh + access tokens for Google and Dropbox OAuth2. Restoring expired or revoked tokens does not make sense. If any is invalid, the OAuth2 authorization loop needs to be done in any case. All other files need to be created on console, manually or via motioneye_init. They do not necessarily need to be writable by the daemon, and should hence be consequently excluded.

In case the config path contains more than 100 files, it was assumed to be "a system-wide config directory", and selective `motion.conf` + `camera-*.conf` were added to the backup already, indicating that these were the major files this feature was intended for. This commit aligns things by doing selective backup in any case, adding the reasonable/harmless `prefs.json` (visual preferences for the GUI), and applying the same file selecting for restoring backups.

For easier OS-agnistic filtering, the native Python `tarfile` module is used instead of the external `tar` command.