### PR TITLE
ci: trigger PyPI release automatically on release tags

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,6 +1,10 @@
 name: PyPI release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+b?[1-9]?'
 
 permissions:
   contents: read


### PR DESCRIPTION
This includes stable releases as well as pre-releases with bX suffix.