### PR TITLE
enh(backup): harden file type and name constraints on restore

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -21,7 +21,7 @@ import tarfile
 from collections import OrderedDict
 from datetime import timedelta
 from errno import EEXIST, ENOENT
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from glob import glob
 from io import BytesIO
 from os import stat
@@ -2129,11 +2129,23 @@ def restore(content: bytes) -> dict | None:
 
     try:
         with tarfile.open(fileobj=BytesIO(content)) as tf:
-            members = [
-                m
-                for m in tf.getmembers()
-                if any(fnmatch(m.name.lstrip('./'), p) for p in patterns)
-            ]
+            members = []
+            for m in tf.getmembers():  # use filter='data' once we require Python 3.12+
+                if not m.isfile():
+                    continue
+
+                # allow leading ./ to support full dir backups from v0.44.0b1 and earlier
+                name = m.name
+                while name.startswith('./'):
+                    name = name[2:]
+
+                # refuse any other directory structure, needed since fnmatchcase() * matches / as well
+                if '/' in name:
+                    continue
+
+                if any(fnmatchcase(name, p) for p in patterns):
+                    members.append(m)
+
             tf.extractall(settings.CONF_PATH, members=members)  # nosec B202
 
         logging.debug('configuration restored successfully')

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -28,7 +28,6 @@ from os import stat
 from re import match, sub
 from secrets import token_hex
 from shlex import split
-from shutil import copyfileobj
 from stat import S_IMODE
 from urllib.parse import quote, urlunparse
 
@@ -2141,23 +2140,13 @@ def restore(content: bytes) -> dict | None:
                     name = name[2:]
 
                 # refuse any other directory structure, needed since fnmatchcase() * matches / as well
-                if '/' in name or '\\' in name:
+                if '/' in name:
                     continue
 
                 if any(fnmatchcase(name, p) for p in patterns):
-                    members.append((name, m))
+                    members.append(m)
 
-            for name, m in members:
-                source = tf.extractfile(m)
-                if source is None:
-                    logging.warning(
-                        f'skipping file with unreadable tar member: {m.name!r}'
-                    )
-                    continue
-                with source, open(
-                    os.path.join(settings.CONF_PATH, name), 'wb'
-                ) as target:
-                    copyfileobj(source, target)
+            tf.extractall(settings.CONF_PATH, members=members)  # nosec B202
 
         logging.debug('configuration restored successfully')
 

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -2150,6 +2150,9 @@ def restore(content: bytes) -> dict | None:
             for name, m in members:
                 source = tf.extractfile(m)
                 if source is None:
+                    logging.warning(
+                        f'skipping file with unreadable tar member: {m.name!r}'
+                    )
                     continue
                 with source, open(
                     os.path.join(settings.CONF_PATH, name), 'wb'

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -28,6 +28,7 @@ from os import stat
 from re import match, sub
 from secrets import token_hex
 from shlex import split
+from shutil import copyfileobj
 from stat import S_IMODE
 from urllib.parse import quote, urlunparse
 
@@ -2140,13 +2141,20 @@ def restore(content: bytes) -> dict | None:
                     name = name[2:]
 
                 # refuse any other directory structure, needed since fnmatchcase() * matches / as well
-                if '/' in name:
+                if '/' in name or '\\' in name:
                     continue
 
                 if any(fnmatchcase(name, p) for p in patterns):
-                    members.append(m)
+                    members.append((name, m))
 
-            tf.extractall(settings.CONF_PATH, members=members)  # nosec B202
+            for name, m in members:
+                source = tf.extractfile(m)
+                if source is None:
+                    continue
+                with source, open(
+                    os.path.join(settings.CONF_PATH, name), 'wb'
+                ) as target:
+                    copyfileobj(source, target)
 
         logging.debug('configuration restored successfully')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -240,19 +240,19 @@ class TestRestore(unittest.TestCase):
         self.assertNotIn('motioneye.conf', files)
 
     def test_restore_ignores_non_regular_members(self):
-        camera_link = tarfile.TarInfo(name='camera-9.conf')
-        camera_link.type = tarfile.SYMTYPE
-        camera_link.linkname = 'motion.conf'
+        camera_symlink_info = tarfile.TarInfo(name='camera-9.conf')
+        camera_symlink_info.type = tarfile.SYMTYPE
+        camera_symlink_info.linkname = 'motion.conf'
 
-        mask_link = tarfile.TarInfo(name='mask_9.pgm')
-        mask_link.type = tarfile.LNKTYPE
-        mask_link.linkname = 'motion.conf'
+        mask_hardlink_info = tarfile.TarInfo(name='mask_9.pgm')
+        mask_hardlink_info.type = tarfile.LNKTYPE
+        mask_hardlink_info.linkname = 'motion.conf'
 
         tarball = self._make_tarball_members(
             [
                 (tarfile.TarInfo(name='motion.conf'), b'[motion]\n'),
-                (camera_link, None),
-                (mask_link, None),
+                (camera_symlink_info, None),
+                (mask_hardlink_info, None),
             ]
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,22 @@ class TestRestore(unittest.TestCase):
                 tf.addfile(info, BytesIO(data))
         return buf.getvalue()
 
+    def _make_tarball_members(
+        self, members: list[tuple[tarfile.TarInfo, bytes | None]]
+    ) -> bytes:
+        """Create an in-memory .tar.gz with raw tar members."""
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode='w:gz') as tf:
+            for info, content in members:
+                if content is None:
+                    tf.addfile(info)
+                    continue
+
+                data = content if isinstance(content, bytes) else content.encode()
+                info.size = len(data)
+                tf.addfile(info, BytesIO(data))
+        return buf.getvalue()
+
     def test_restore_extracts_motion_conf(self):
         content = b'[motion]\ndaemon = on\n'
         tarball = self._make_tarball({'motion.conf': content})
@@ -222,6 +238,77 @@ class TestRestore(unittest.TestCase):
         self.assertNotIn('uploadservices.json', files)
         self.assertNotIn('secrets.json', files)
         self.assertNotIn('motioneye.conf', files)
+
+    def test_restore_ignores_non_regular_members(self):
+        camera_link = tarfile.TarInfo(name='camera-9.conf')
+        camera_link.type = tarfile.SYMTYPE
+        camera_link.linkname = 'motion.conf'
+
+        mask_link = tarfile.TarInfo(name='mask_9.pgm')
+        mask_link.type = tarfile.LNKTYPE
+        mask_link.linkname = 'motion.conf'
+
+        tarball = self._make_tarball_members(
+            [
+                (tarfile.TarInfo(name='motion.conf'), b'[motion]\n'),
+                (camera_link, None),
+                (mask_link, None),
+            ]
+        )
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = os.listdir(self.conf_dir)
+        self.assertIn('motion.conf', files)
+        self.assertNotIn('camera-9.conf', files)
+        self.assertNotIn('mask_9.pgm', files)
+
+    def test_restore_ignores_absolute_paths(self):
+        tarball = self._make_tarball(
+            {
+                '/motion.conf': b'ignored',
+                '/camera-1.conf': b'ignored',
+                '/mask_1.pgm': b'ignored',
+                '/prefs.json': b'ignored',
+                'motion.conf': b'[motion]\n',
+            }
+        )
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = os.listdir(self.conf_dir)
+        self.assertIn('motion.conf', files)
+        self.assertNotIn('camera-1.conf', files)
+        self.assertNotIn('mask_1.pgm', files)
+        self.assertNotIn('prefs.json', files)
+
+    def test_restore_ignores_pattern_matches_with_path_elements(self):
+        tarball = self._make_tarball(
+            {
+                'camera-1.conf': b'camera 1',
+                'mask_1.pgm': b'P5\n',
+                'subdir/camera-2.conf': b'ignored',
+                'camera-3.conf/extra': b'ignored',
+                './subdir/camera-4.conf': b'ignored',
+                '../camera-5.conf': b'ignored',
+                'subdir/mask_2.pgm': b'ignored',
+                './subdir/mask_3.pgm': b'ignored',
+                '../mask_4.pgm': b'ignored',
+            }
+        )
+
+        result = config.restore(tarball)
+        self.assertIsNotNone(result)
+        files = os.listdir(self.conf_dir)
+        self.assertIn('camera-1.conf', files)
+        self.assertIn('mask_1.pgm', files)
+        self.assertNotIn('camera-2.conf', files)
+        self.assertNotIn('camera-3.conf', files)
+        self.assertNotIn('camera-4.conf', files)
+        self.assertNotIn('camera-5.conf', files)
+        self.assertNotIn('mask_2.pgm', files)
+        self.assertNotIn('mask_3.pgm', files)
+        self.assertNotIn('mask_4.pgm', files)
 
     def test_restore_accepts_dot_slash_prefix(self):
         """Tarball entries prefixed with ./ (e.g. from GNU tar) should still be accepted."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -176,13 +176,16 @@ class TestRestore(unittest.TestCase):
                 tf.addfile(info, BytesIO(data))
         return buf.getvalue()
 
+    def _assert_restored_files(self, expected: list[str]):
+        self.assertEqual(sorted(os.listdir(self.conf_dir)), sorted(expected))
+
     def test_restore_extracts_motion_conf(self):
         content = b'[motion]\ndaemon = on\n'
         tarball = self._make_tarball({'motion.conf': content})
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('motion.conf', os.listdir(self.conf_dir))
+        self._assert_restored_files(['motion.conf'])
         with open(os.path.join(self.conf_dir, 'motion.conf'), 'rb') as f:
             self.assertEqual(f.read(), content)
 
@@ -196,9 +199,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('camera-1.conf', files)
-        self.assertIn('camera-42.conf', files)
+        self._assert_restored_files(['camera-1.conf', 'camera-42.conf'])
 
     def test_restore_extracts_mask_files(self):
         tarball = self._make_tarball(
@@ -210,16 +211,14 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('mask_1.pgm', files)
-        self.assertIn('mask_2.pgm', files)
+        self._assert_restored_files(['mask_1.pgm', 'mask_2.pgm'])
 
     def test_restore_extracts_prefs_json(self):
         tarball = self._make_tarball({'prefs.json': b'{}'})
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('prefs.json', os.listdir(self.conf_dir))
+        self._assert_restored_files(['prefs.json'])
 
     def test_restore_ignores_non_matching_files(self):
         tarball = self._make_tarball(
@@ -233,11 +232,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('motion.conf', files)
-        self.assertNotIn('uploadservices.json', files)
-        self.assertNotIn('secrets.json', files)
-        self.assertNotIn('motioneye.conf', files)
+        self._assert_restored_files(['motion.conf'])
 
     def test_restore_ignores_non_regular_members(self):
         camera_symlink_info = tarfile.TarInfo(name='camera-9.conf')
@@ -258,10 +253,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('motion.conf', files)
-        self.assertNotIn('camera-9.conf', files)
-        self.assertNotIn('mask_9.pgm', files)
+        self._assert_restored_files(['motion.conf'])
 
     def test_restore_ignores_absolute_paths(self):
         tarball = self._make_tarball(
@@ -276,11 +268,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('motion.conf', files)
-        self.assertNotIn('camera-1.conf', files)
-        self.assertNotIn('mask_1.pgm', files)
-        self.assertNotIn('prefs.json', files)
+        self._assert_restored_files(['motion.conf'])
 
     def test_restore_ignores_pattern_matches_with_path_elements(self):
         tarball = self._make_tarball(
@@ -299,16 +287,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        files = os.listdir(self.conf_dir)
-        self.assertIn('camera-1.conf', files)
-        self.assertIn('mask_1.pgm', files)
-        self.assertNotIn('camera-2.conf', files)
-        self.assertNotIn('camera-3.conf', files)
-        self.assertNotIn('camera-4.conf', files)
-        self.assertNotIn('camera-5.conf', files)
-        self.assertNotIn('mask_2.pgm', files)
-        self.assertNotIn('mask_3.pgm', files)
-        self.assertNotIn('mask_4.pgm', files)
+        self._assert_restored_files(['camera-1.conf', 'mask_1.pgm'])
 
     def test_restore_accepts_dot_slash_prefix(self):
         """Tarball entries prefixed with ./ (e.g. from GNU tar) should still be accepted."""
@@ -316,7 +295,7 @@ class TestRestore(unittest.TestCase):
 
         result = config.restore(tarball)
         self.assertIsNotNone(result)
-        self.assertIn('motion.conf', os.listdir(self.conf_dir))
+        self._assert_restored_files(['motion.conf'])
 
     def test_restore_returns_reboot_false(self):
         tarball = self._make_tarball({'motion.conf': b'[motion]\n'})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,77 +45,55 @@ class TestBackup(unittest.TestCase):
         for name in os.listdir(self.conf_dir):
             os.remove(os.path.join(self.conf_dir, name))
 
-    def _write(self, filename, content=b''):
-        path = os.path.join(self.conf_dir, filename)
-        with open(path, 'wb') as f:
-            f.write(content)
+    def _create_files(self, *names: str) -> None:
+        for name in names:
+            open(os.path.join(self.conf_dir, name), 'a').close()
 
-    def _get_tarball_names(self, data: bytes) -> list:
+    def _assert_tarball_members(self, data: bytes | None, expected: list[str]) -> None:
+        if data is None:
+            self.fail('tarball data is None')
+
         with tarfile.open(fileobj=BytesIO(data)) as tf:
-            return tf.getnames()
-
-    def _assert_tarball_members(self, data: bytes, expected: list[str]):
-        self.assertEqual(sorted(self._get_tarball_names(data)), sorted(expected))
+            members = tf.getnames()
+        self.assertEqual(sorted(members), sorted(expected))
 
     def test_backup_includes_motion_conf(self):
-        self._write('motion.conf', b'[motion]\n')
+        self._create_files('motion.conf')
 
         data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_includes_camera_confs(self):
-        self._write('camera-1.conf', b'camera 1\n')
-        self._write('camera-2.conf', b'camera 2\n')
+        self._create_files('camera-1.conf', 'camera-2.conf')
 
         data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, ['camera-1.conf', 'camera-2.conf'])
 
     def test_backup_includes_mask_files(self):
-        self._write('mask_1.pgm', b'P5\n')
-        self._write('mask_2.pgm', b'P5\n')
+        self._create_files('mask_1.pgm', 'mask_2.pgm')
 
         data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, ['mask_1.pgm', 'mask_2.pgm'])
 
     def test_backup_includes_prefs_json(self):
-        self._write('prefs.json', b'{}')
+        self._create_files('prefs.json')
 
         data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, ['prefs.json'])
 
     def test_backup_excludes_other_files(self):
-        self._write('motion.conf', b'[motion]\n')
-        self._write('uploadservices.json', b'{}')
-        self._write('secrets.json', b'{}')
-        self._write('motioneye.conf', b'secret=password\n')
+        self._create_files(
+            'motion.conf',
+            'uploadservices.json',
+            'secrets.json',
+            'motioneye.conf',
+        )
 
         data = config.backup()
-        self.assertIsNotNone(data)
-        self._assert_tarball_members(data, ['motion.conf'])
-
-    def test_backup_omits_missing_mask_files(self):
-        self._write('motion.conf', b'[motion]\n')
-        # mask_*.pgm intentionally not created
-
-        data = config.backup()
-        self.assertIsNotNone(data)
-        self._assert_tarball_members(data, ['motion.conf'])
-
-    def test_backup_omits_missing_prefs_json(self):
-        self._write('motion.conf', b'[motion]\n')
-        # prefs.json intentionally not created
-
-        data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_empty_dir_returns_empty_tarball(self):
         data = config.backup()
-        self.assertIsNotNone(data)
         self._assert_tarball_members(data, [])
 
 
@@ -143,159 +121,120 @@ class TestRestore(unittest.TestCase):
         for name in os.listdir(self.conf_dir):
             os.remove(os.path.join(self.conf_dir, name))
 
-    def _make_tarball(self, files: dict) -> bytes:
-        """Create an in-memory .tar.gz with the given filename->content mapping."""
+    def _make_tarball(self, *names: str) -> bytes:
+        """Create an in-memory .tar.gz with the given file names as empty members."""
         buf = BytesIO()
         with tarfile.open(fileobj=buf, mode='w:gz') as tf:
-            for name, content in files.items():
-                data = content if isinstance(content, bytes) else content.encode()
-                info = tarfile.TarInfo(name=name)
-                info.size = len(data)
-                tf.addfile(info, BytesIO(data))
+            for name in names:
+                member = tarfile.TarInfo(name)
+                member.size = 0
+                tf.addfile(member)
         return buf.getvalue()
 
-    def _make_tarball_members(
-        self, members: list[tuple[tarfile.TarInfo, bytes | None]]
-    ) -> bytes:
-        """Create an in-memory .tar.gz with raw tar members."""
+    def _make_tarball_members(self, *members: tarfile.TarInfo) -> bytes:
+        """Create an in-memory .tar.gz with the given raw members."""
         buf = BytesIO()
         with tarfile.open(fileobj=buf, mode='w:gz') as tf:
-            for info, content in members:
-                if content is None:
-                    tf.addfile(info)
-                    continue
-
-                data = content if isinstance(content, bytes) else content.encode()
-                info.size = len(data)
-                tf.addfile(info, BytesIO(data))
+            for member in members:
+                tf.addfile(member)
         return buf.getvalue()
 
-    def _assert_restored_files(self, expected: list[str]):
+    def _assert_restored_files(self, *expected: str) -> None:
         self.assertEqual(sorted(os.listdir(self.conf_dir)), sorted(expected))
 
     def test_restore_extracts_motion_conf(self):
-        content = b'[motion]\ndaemon = on\n'
-        tarball = self._make_tarball({'motion.conf': content})
+        tarball = self._make_tarball('motion.conf')
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['motion.conf'])
-        with open(os.path.join(self.conf_dir, 'motion.conf'), 'rb') as f:
-            self.assertEqual(f.read(), content)
+        config.restore(tarball)
+        self._assert_restored_files('motion.conf')
 
     def test_restore_extracts_camera_confs(self):
-        tarball = self._make_tarball(
-            {
-                'camera-1.conf': b'camera 1',
-                'camera-42.conf': b'camera 42',
-            }
-        )
+        tarball = self._make_tarball('camera-1.conf', 'camera-42.conf')
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['camera-1.conf', 'camera-42.conf'])
+        config.restore(tarball)
+        self._assert_restored_files('camera-1.conf', 'camera-42.conf')
 
     def test_restore_extracts_mask_files(self):
-        tarball = self._make_tarball(
-            {
-                'mask_1.pgm': b'P5\n',
-                'mask_2.pgm': b'P5\n',
-            }
-        )
+        tarball = self._make_tarball('mask_1.pgm', 'mask_2.pgm')
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['mask_1.pgm', 'mask_2.pgm'])
+        config.restore(tarball)
+        self._assert_restored_files('mask_1.pgm', 'mask_2.pgm')
 
     def test_restore_extracts_prefs_json(self):
-        tarball = self._make_tarball({'prefs.json': b'{}'})
+        tarball = self._make_tarball('prefs.json')
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['prefs.json'])
+        config.restore(tarball)
+        self._assert_restored_files('prefs.json')
 
     def test_restore_ignores_non_matching_files(self):
         tarball = self._make_tarball(
-            {
-                'motion.conf': b'[motion]\n',
-                'uploadservices.json': b'{}',
-                'secrets.json': b'{}',
-                'motioneye.conf': b'secret=password\n',
-            }
+            'motion.conf',
+            'uploadservices.json',
+            'secrets.json',
+            'motioneye.conf',
         )
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['motion.conf'])
+        config.restore(tarball)
+        self._assert_restored_files('motion.conf')
 
     def test_restore_ignores_non_regular_members(self):
-        camera_symlink_info = tarfile.TarInfo(name='camera-9.conf')
-        camera_symlink_info.type = tarfile.SYMTYPE
-        camera_symlink_info.linkname = 'motion.conf'
+        motion_config = tarfile.TarInfo(name='motion.conf')
+        motion_config.size = 0
 
-        mask_hardlink_info = tarfile.TarInfo(name='mask_9.pgm')
-        mask_hardlink_info.type = tarfile.LNKTYPE
-        mask_hardlink_info.linkname = 'motion.conf'
+        camera_symlink = tarfile.TarInfo(name='camera-9.conf')
+        camera_symlink.type = tarfile.SYMTYPE
+        camera_symlink.linkname = 'motion.conf'
+
+        mask_hardlink = tarfile.TarInfo(name='mask_9.pgm')
+        mask_hardlink.type = tarfile.LNKTYPE
+        mask_hardlink.linkname = 'motion.conf'
 
         tarball = self._make_tarball_members(
-            [
-                (tarfile.TarInfo(name='motion.conf'), b'[motion]\n'),
-                (camera_symlink_info, None),
-                (mask_hardlink_info, None),
-            ]
+            motion_config, camera_symlink, mask_hardlink
         )
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['motion.conf'])
+        config.restore(tarball)
+        self._assert_restored_files('motion.conf')
 
     def test_restore_ignores_absolute_paths(self):
         tarball = self._make_tarball(
-            {
-                '/motion.conf': b'ignored',
-                '/camera-1.conf': b'ignored',
-                '/mask_1.pgm': b'ignored',
-                '/prefs.json': b'ignored',
-                'motion.conf': b'[motion]\n',
-            }
+            '/motion.conf',
+            '/camera-1.conf',
+            '/mask_1.pgm',
+            '/prefs.json',
+            'motion.conf',
         )
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['motion.conf'])
+        config.restore(tarball)
+        self._assert_restored_files('motion.conf')
 
     def test_restore_ignores_pattern_matches_with_path_elements(self):
         tarball = self._make_tarball(
-            {
-                'camera-1.conf': b'camera 1',
-                'mask_1.pgm': b'P5\n',
-                'subdir/camera-2.conf': b'ignored',
-                'camera-3.conf/extra': b'ignored',
-                './subdir/camera-4.conf': b'ignored',
-                '../camera-5.conf': b'ignored',
-                'subdir/mask_2.pgm': b'ignored',
-                './subdir/mask_3.pgm': b'ignored',
-                '../mask_4.pgm': b'ignored',
-            }
+            'camera-1.conf',
+            'mask_1.pgm',
+            'subdir/camera-2.conf',
+            'camera-3.conf/extra',
+            './subdir/camera-4.conf',
+            '../camera-5.conf',
+            'subdir/mask_2.pgm',
+            './subdir/mask_3.pgm',
+            '../mask_4.pgm',
         )
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['camera-1.conf', 'mask_1.pgm'])
+        config.restore(tarball)
+        self._assert_restored_files('camera-1.conf', 'mask_1.pgm')
 
     def test_restore_accepts_dot_slash_prefix(self):
         """Tarball entries prefixed with ./ (e.g. from GNU tar) should still be accepted."""
-        tarball = self._make_tarball({'./motion.conf': b'[motion]\n'})
+        tarball = self._make_tarball('./motion.conf')
 
-        result = config.restore(tarball)
-        self.assertIsNotNone(result)
-        self._assert_restored_files(['motion.conf'])
+        config.restore(tarball)
+        self._assert_restored_files('motion.conf')
 
     def test_restore_returns_reboot_false(self):
-        tarball = self._make_tarball({'motion.conf': b'[motion]\n'})
+        tarball = self._make_tarball('motion.conf')
 
         result = config.restore(tarball)
-        self.assertIsNotNone(result)
         self.assertEqual(result, {'reboot': False})
 
     def test_restore_invalid_data_returns_none(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,12 +54,15 @@ class TestBackup(unittest.TestCase):
         with tarfile.open(fileobj=BytesIO(data)) as tf:
             return tf.getnames()
 
+    def _assert_tarball_members(self, data: bytes, expected: list[str]):
+        self.assertEqual(sorted(self._get_tarball_names(data)), sorted(expected))
+
     def test_backup_includes_motion_conf(self):
         self._write('motion.conf', b'[motion]\n')
 
         data = config.backup()
         self.assertIsNotNone(data)
-        self.assertIn('motion.conf', self._get_tarball_names(data))
+        self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_includes_camera_confs(self):
         self._write('camera-1.conf', b'camera 1\n')
@@ -67,9 +70,7 @@ class TestBackup(unittest.TestCase):
 
         data = config.backup()
         self.assertIsNotNone(data)
-        names = self._get_tarball_names(data)
-        self.assertIn('camera-1.conf', names)
-        self.assertIn('camera-2.conf', names)
+        self._assert_tarball_members(data, ['camera-1.conf', 'camera-2.conf'])
 
     def test_backup_includes_mask_files(self):
         self._write('mask_1.pgm', b'P5\n')
@@ -77,16 +78,14 @@ class TestBackup(unittest.TestCase):
 
         data = config.backup()
         self.assertIsNotNone(data)
-        names = self._get_tarball_names(data)
-        self.assertIn('mask_1.pgm', names)
-        self.assertIn('mask_2.pgm', names)
+        self._assert_tarball_members(data, ['mask_1.pgm', 'mask_2.pgm'])
 
     def test_backup_includes_prefs_json(self):
         self._write('prefs.json', b'{}')
 
         data = config.backup()
         self.assertIsNotNone(data)
-        self.assertIn('prefs.json', self._get_tarball_names(data))
+        self._assert_tarball_members(data, ['prefs.json'])
 
     def test_backup_excludes_other_files(self):
         self._write('motion.conf', b'[motion]\n')
@@ -96,10 +95,7 @@ class TestBackup(unittest.TestCase):
 
         data = config.backup()
         self.assertIsNotNone(data)
-        names = self._get_tarball_names(data)
-        self.assertNotIn('uploadservices.json', names)
-        self.assertNotIn('secrets.json', names)
-        self.assertNotIn('motioneye.conf', names)
+        self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_omits_missing_mask_files(self):
         self._write('motion.conf', b'[motion]\n')
@@ -107,8 +103,7 @@ class TestBackup(unittest.TestCase):
 
         data = config.backup()
         self.assertIsNotNone(data)
-        names = self._get_tarball_names(data)
-        self.assertFalse(any(n.startswith('mask_') for n in names))
+        self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_omits_missing_prefs_json(self):
         self._write('motion.conf', b'[motion]\n')
@@ -116,13 +111,12 @@ class TestBackup(unittest.TestCase):
 
         data = config.backup()
         self.assertIsNotNone(data)
-        names = self._get_tarball_names(data)
-        self.assertNotIn('prefs.json', names)
+        self._assert_tarball_members(data, ['motion.conf'])
 
     def test_backup_empty_dir_returns_empty_tarball(self):
         data = config.backup()
         self.assertIsNotNone(data)
-        self.assertEqual(self._get_tarball_names(data), [])
+        self._assert_tarball_members(data, [])
 
 
 class TestRestore(unittest.TestCase):


### PR DESCRIPTION
Once we support Python 3.12+ only, we can use `filter='data'` instead, or additionally, which refuses to extract any kind of link, normalizes paths, skips owner/mode, and more more. With our hardcoded strict filename pattern and the `isfile()` check, however, all security concerns are addressed.