### PR TITLE
Translate working schedule labels for all days

### DIFF
--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -1263,8 +1263,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Mardo") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="tuesdayEnabledSwitch">
-                                <span id="tuesdayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="tuesdayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="tuesdayToEntry"></span>
+                                <span id="tuesdayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="tuesdayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="tuesdayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por mardoj.") }}">?</span></td>
                         </tr>
@@ -1272,8 +1272,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Merkredo") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="wednesdayEnabledSwitch">
-                                <span id="wednesdayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="wednesdayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="wednesdayToEntry"></span>
+                                <span id="wednesdayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="wednesdayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="wednesdayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por merkredoj.") }}">?</span></td>
                         </tr>
@@ -1281,8 +1281,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Ĵaŭdo") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="thursdayEnabledSwitch">
-                                <span id="thursdayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="thursdayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="thursdayToEntry"></span>
+                                <span id="thursdayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="thursdayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="thursdayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por ĵaŭdoj.") }}">?</span></td>
                         </tr>
@@ -1290,8 +1290,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Vendredo") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="fridayEnabledSwitch">
-                                <span id="fridayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="fridayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="fridayToEntry"></span>
+                                <span id="fridayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="fridayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="fridayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por vendredoj.") }}">?</span></td>
                         </tr>
@@ -1299,8 +1299,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Sabato") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="saturdayEnabledSwitch">
-                                <span id="saturdayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="saturdayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="saturdayToEntry"></span>
+                                <span id="saturdayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="saturdayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="saturdayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por sabatoj.") }}">?</span></td>
                         </tr>
@@ -1308,8 +1308,8 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Dimanĉo") }}</span></td>
                             <td class="settings-item-value">
                                 <input type="checkbox" class="styled working-schedule camera-config" id="sundayEnabledSwitch">
-                                <span id="sundayTimeInputs"><span class="settings-item-unit">from</span><input type="time" class="styled working-schedule camera-config" id="sundayFromEntry">
-                                <span class="settings-item-unit">to</span><input type="time" class="styled working-schedule camera-config" id="sundayToEntry"></span>
+                                <span id="sundayTimeInputs"><span class="settings-item-unit">{{ _("de") }}</span><input type="time" class="styled working-schedule camera-config" id="sundayFromEntry">
+                                <span class="settings-item-unit">{{ _("ĝis") }}</span><input type="time" class="styled working-schedule camera-config" id="sundayToEntry"></span>
                             </td>
                             <td><span class="help-mark" title="{{ _("Fiksas la labortagan tempintervalon por dimanĉoj.") }}">?</span></td>
                         </tr>


### PR DESCRIPTION
In the working schedule menu, only "from" and "to" for Monday were translated, while Tuesday through Sunday still used hard-coded English text.

Apply the existing gettext labels to every day so the schedule is translated consistently across the full week.