### PR TITLE
Fix endless motion restart loop when motion is not a direct child (ECHILD)

### DIFF
--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -194,15 +194,26 @@ def running():
     if pid is None:
         return False
 
+    # Best-effort reap: if motion is our child and has already exited, collect
+    # it so a dead process is not later reported as running. ECHILD here only
+    # means motion is not a direct child of this process (e.g. when launched by
+    # a process supervisor such as s6 in the Home Assistant add-on) and must NOT
+    # be treated as "not running" -- doing so triggers an endless restart loop.
     try:
         os.waitpid(pid, os.WNOHANG)
+    except OSError as e:
+        if e.errno not in (errno.ESRCH, errno.ECHILD):
+            raise
+
+    # The actual liveness check. Only ESRCH means the process is gone.
+    try:
         os.kill(pid, 0)
 
         # the process is running
         return True
 
     except OSError as e:
-        if e.errno not in (errno.ESRCH, errno.ECHILD):
+        if e.errno != errno.ESRCH:
             raise
 
     return False


### PR DESCRIPTION
### Problem

`motionctl.running()` reports a healthy `motion` process as **not running** whenever `motion` is not a *direct* child of the motionEye process. motionEye's watchdog then kills and restarts `motion` on every check interval, producing an endless restart loop that makes motionEye unusable (cameras never come up, logs spam `motion not running, starting it`).

This happens in any setup where a process supervisor sits between motionEye and `motion`, most notably the **official Home Assistant add-on** (s6-overlay), and more generally any container/supervisor launch context.

### Root cause

```python
try:
    os.waitpid(pid, os.WNOHANG)
    os.kill(pid, 0)
    return True
except OSError as e:
    if e.errno not in (errno.ESRCH, errno.ECHILD):
        raise
return False
```

`os.waitpid()` and `os.kill()` share one `try` block that swallows both `ESRCH` and `ECHILD`. When `motion` is not a child of the calling process, `os.waitpid()` raises `OSError(ECHILD)` **before** `os.kill()` ever executes. `ECHILD` is in the ignore list, so the function falls through to `return False` — even though `os.kill(pid, 0)` would have confirmed the process is alive.

### Fix

Separate the best-effort zombie reap from the liveness check:

- `os.waitpid()` is now a standalone best-effort call. `ECHILD` (motion is not our child) and `ESRCH` are ignored — reaping is only meaningful when motion *is* our child.
- Liveness is decided solely by `os.kill(pid, 0)`, where only `ESRCH` means the process is gone.

This keeps zombie-reaping behaviour intact when motion *is* a direct child, while no longer misreporting it as dead when it is supervised by something else.

### Testing

- Verified on a Home Assistant add-on install (aarch64): before the patch, `motion` restarted every check interval; after, it stays up and cameras work.
- `os.kill(pid, 0)` remains the authoritative liveness probe in both the child and non-child cases.
