### PR TITLE
Fix no-camera placeholder image aspect ratio

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -4634,7 +4634,7 @@ function addCameraFrameUi(cameraConfig) {
     var cameraFrameDiv = $(
             '<div class="camera-frame">' +
                 '<div class="camera-container">' +
-                    '<div class="camera-placeholder"><img class="no-camera" src="' + staticPath + 'img/no-camera.svg" width=16 height=16></div>' +
+                    '<div class="camera-placeholder"><img class="no-camera" src="' + staticPath + 'img/no-camera.svg"></div>' +
                     '<img class="camera">' +
                     '<div class="camera-progress"><img class="camera-progress"></div>' +
                 '</div>' +


### PR DESCRIPTION
The no-camera SVG placeholder was being squashed because the inline `height="16"` attribute kept the height fixed while the CSS rule `width: 30%` scaled the width freely.
Removed the inline `width="16"` and `height="16"` attributes. By only declaring `width: 30%` in CSS, the aspect ratio is preserved automatically.
https://github.com/motioneye-project/motioneye/blob/2b7327a1334e185b3a837ec0949f367a2f17d7be/motioneye/static/css/main.css#L1274-L1277

<table>
<tr>
<td align="center">Before</td>
<td align="center">After</td>
</tr>
<tr>
<td>
<img width="400" alt="before" src="https://github.com/user-attachments/assets/ed9e8cc2-ee91-4429-b649-f9f4422f2d5e" />
</td>
<td>
<img width="400" alt="after" src="https://github.com/user-attachments/assets/399b053e-04f0-4ebf-a5cb-0c6b09bf0f54" />
</td>
</tr>
</table>
