### PR TITLE
Add dialog for editing camera credentials

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -694,6 +694,28 @@ def set_camera(camera_id, camera_config):
         f.close()
 
 
+def make_netcam_userpass(url, raw_username, raw_password, camera_id):
+    raw_username = str(raw_username)
+    raw_password = str(raw_password)
+
+    # Motion's mjpeg/mjpg/jpeg/ftp auth handling expects plain userpass here.
+    if url.lower().startswith(('mjpeg', 'mjpg', 'jpeg', 'ftp')):
+        userpass = f'{raw_username}:{raw_password}'
+    else:
+        # For other protocols, credentials go to ffmpeg as URL userinfo,
+        # so reserved characters (e.g. "@", "#") must be percent-encoded.
+        username = quote(raw_username, safe='')
+        password = quote(raw_password, safe='')
+        userpass = f'{username}:{password}'
+
+        if username != raw_username or password != raw_password:
+            logging.debug(
+                f'credentials for camera {camera_id} have been percent-encoded'
+            )
+
+    return userpass
+
+
 def add_camera(device_details):
     global _camera_ids_cache
 
@@ -747,25 +769,12 @@ def add_camera(device_details):
         camera_config['netcam_url'] = device_details['url']
 
         if device_details['username']:
-            raw_username = str(device_details['username'])
-            raw_password = str(device_details['password'])
-
-            # Motion's mjpeg/mjpg/jpeg/ftp auth handling expects plain userpass here.
-            if camera_config['netcam_url'].startswith(('mjpeg', 'mjpg', 'jpeg', 'ftp')):
-                userpass = f"{raw_username}:{raw_password}"
-            else:
-                # For other protocols, credentials go to ffmpeg as URL userinfo,
-                # so reserved characters (e.g. "@", "#") must be percent-encoded.
-                username = quote(raw_username, safe='')
-                password = quote(raw_password, safe='')
-                userpass = f'{username}:{password}'
-
-                if username != raw_username or password != raw_password:
-                    logging.debug(
-                        f'credentials for camera {camera_id} have been percent-encoded'
-                    )
-
-            camera_config['netcam_userpass'] = userpass
+            camera_config['netcam_userpass'] = make_netcam_userpass(
+                camera_config['netcam_url'],
+                device_details['username'],
+                device_details['password'],
+                camera_id,
+            )
 
         camera_config['netcam_keepalive'] = device_details.get('keep_alive', False)
         camera_config['netcam_tolerant_check'] = True

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import socket
+from urllib.parse import urlparse
 
 from tornado.ioloop import IOLoop
 from tornado.web import HTTPError
@@ -90,11 +91,65 @@ class ConfigHandler(BaseHandler):
             await self.list()
             return
 
+        elif op == 'credentials':
+            return await self.set_credentials(camera_id)
+
         elif op == 'test':
             await self.test(camera_id)
 
         else:
             raise HTTPError(400, 'unknown operation')
+
+    @BaseHandler.auth(admin=True)
+    async def set_credentials(self, camera_id):
+        if camera_id not in config.get_camera_ids():
+            raise HTTPError(404, 'no such camera')
+
+        try:
+            data = json.loads(self.request.body)
+        except Exception as e:
+            logging.error(f'could not decode json: {str(e)}')
+            raise HTTPError(400, 'invalid json body')
+
+        url = data.get('url')
+        if not url:
+            raise HTTPError(400, 'url is required')
+
+        local_config = config.get_camera(camera_id)
+
+        if utils.is_remote_camera(local_config):
+            parsed = urlparse(url)
+            local_config['@scheme'] = parsed.scheme or 'http'
+            local_config['@host'] = parsed.hostname or ''
+            local_config['@port'] = str(parsed.port) if parsed.port is not None else ''
+            local_config['@path'] = parsed.path or '/'
+            if data.get('remote_secret'):
+                local_config['@remote_secret'] = data['remote_secret']
+            config.set_camera(camera_id, local_config)
+            return self.finish_json()
+
+        elif utils.is_simple_mjpeg_camera(local_config):
+            local_config['@url'] = url
+            config.set_camera(camera_id, local_config)
+            return self.finish_json()
+
+        elif utils.is_net_camera(local_config):
+            local_config['netcam_url'] = url
+
+            username = data.get('username') or ''
+            password = data.get('password') or ''
+            if 'username' in data or 'password' in data:
+                local_config['netcam_userpass'] = config.make_netcam_userpass(
+                    url, username, password, camera_id
+                )
+
+            config.set_camera(camera_id, local_config)
+            motionctl.stop()
+            motionctl.start()
+            return self.finish_json()
+
+        else:
+            raise HTTPError(400, 'unsupported camera type for credential update')
 
     @BaseHandler.auth(admin=True)
     @BaseHandler.peer_allowed()
@@ -117,7 +172,15 @@ class ConfigHandler(BaseHandler):
                     msg = 'Failed to get remote camera configuration for {url}: {msg}.'.format(
                         url=remote.pretty_camera_url(local_config), msg=resp.error
                     )
-                    return self.finish_json_with_error(msg)
+                    return self.finish_json(
+                        {
+                            'error': msg,
+                            'connection_failed': True,
+                            'connection_url': remote.pretty_camera_url(
+                                local_config, camera=False
+                            ),
+                        }
+                    )
 
                 for key, value in list(local_config.items()):
                     if key == '@remote_secret':
@@ -376,11 +439,17 @@ class ConfigHandler(BaseHandler):
         length: list,
     ) -> None:
         if resp.error:
+            msg = f'Failed to get remote camera configuration for {remote.pretty_camera_url(local_config)}: {resp.error}.'
             cameras.append(
                 {
                     'id': camera_id,
-                    'name': '&lt;' + remote.pretty_camera_url(local_config) + '&gt;',
+                    'name': f'Camera {camera_id} - Connection failed',
                     'enabled': False,
+                    'connection_failed': True,
+                    'connection_error': msg,
+                    'connection_url': remote.pretty_camera_url(
+                        local_config, camera=False
+                    ),
                     'streaming_framerate': 1,
                     'framerate': 1,
                 }

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -108,7 +108,7 @@ class ConfigHandler(BaseHandler):
         try:
             data = json.loads(self.request.body)
         except Exception as e:
-            logging.error(f'could not decode json: {str(e)}')
+            logging.error(f'could not decode json: {e}')
             raise HTTPError(400, 'invalid json body')
 
         url = data.get('url')

--- a/motioneye/server.py
+++ b/motioneye/server.py
@@ -189,7 +189,7 @@ handler_mapping: Sequence[Tuple] = [
     (r'^/manifest.json$', ManifestHandler),
     (r'^/config/main/(?P<op>set|get)/?$', ConfigHandler),
     (
-        r'^/config/(?P<camera_id>\d+)/(?P<op>get|set|rem|test|authorize)/?$',
+        r'^/config/(?P<camera_id>\d+)/(?P<op>get|set|rem|test|authorize|credentials)/?$',
         ConfigHandler,
     ),
     (r'^/config/(?P<op>add|list|backup|restore)/?$', ConfigHandler),

--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -384,6 +384,7 @@ div.normal-button {
 div.update-button,
 div.backup-button,
 div.restore-button,
+div.edit-credentials-button,
 div.edit-mask-button,
 div.save-mask-button,
 div.clear-mask-button,
@@ -404,6 +405,7 @@ div.reboot-button {
 div.update-button:HOVER,
 div.backup-button:HOVER,
 div.restore-button:HOVER,
+div.edit-credentials-button:HOVER,
 div.edit-mask-button:HOVER,
 div.save-mask-button:HOVER,
 div.clear-mask-button:HOVER,
@@ -419,6 +421,7 @@ div.reboot-button:HOVER {
 div.update-button:ACTIVE,
 div.backup-button:ACTIVE,
 div.restore-button:ACTIVE,
+div.edit-credentials-button:ACTIVE,
 div.edit-mask-button:ACTIVE,
 div.save-mask-button:ACTIVE,
 div.clear-mask-button:ACTIVE,
@@ -522,13 +525,16 @@ table.login-dialog {
     font-size: 22px; /* always bigger, regardless of screen size */
 }
 
-table.add-camera-dialog {
+table.add-camera-dialog,
+table.edit-credentials-dialog {
     margin: auto;
 }
 
 table.add-camera-dialog select,
 table.add-camera-dialog input[type=text],
-table.add-camera-dialog input[type=password] {
+table.add-camera-dialog input[type=password],
+table.edit-credentials-dialog input[type=text],
+table.edit-credentials-dialog input[type=password] {
     width: 17em;
 }
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -843,6 +843,9 @@ function initUI() {
             var cameraFrame = getCameraFrame(cameraId);
             url = cameraFrame.length ? cameraFrame[0].config.url : '';
         }
+        else if (proto == 'motioneye') {
+            url = url.replace(/config\/\d+$/, '');
+        }
 
         runEditCredentialsDialog(cameraId, {proto: proto, url: url});
     });
@@ -2120,7 +2123,7 @@ function dict2CameraUi(dict) {
     $('#deviceUrlEntry').val(dict['device_url']); markHideIfNull('device_url', 'deviceUrlEntry');
     $('#deviceTypeEntry').val(prettyType); markHideIfNull(!prettyType, 'deviceTypeEntry');
     $('#deviceTypeEntry')[0].proto = dict['proto'];
-    markHideIfNull(!['netcam', 'mjpeg'].includes(dict['proto']), 'editCredentialsButton');
+    markHideIfNull(!['netcam', 'mjpeg', 'motioneye'].includes(dict['proto']), 'editCredentialsButton');
     $('#adminOnlySwitch')[0].checked = dict['admin_only']; markHideIfNull('admin_only', 'adminOnlySwitch');
     $('#autoBrightnessSwitch')[0].checked = dict['auto_brightness']; markHideIfNull('auto_brightness', 'autoBrightnessSwitch');
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -746,9 +746,19 @@ function initUI() {
         this._prevSelectedIndex = this.selectedIndex;
 
     }).on('change', function () {
+        var selectedOption = $(this).find('option:selected');
         if ($('#cameraSelect').val() === 'add') {
             runAddCameraDialog();
             this.selectedIndex = this._prevSelectedIndex;
+        }
+        else if (selectedOption.attr('data-connection-failed') == 'true') {
+            this._prevSelectedIndex = this.selectedIndex;
+            showErrorMessage(selectedOption.attr('data-connection-error'));
+            dict2CameraUi(null);
+            runEditCredentialsDialog($(this).val(), {
+                proto: 'motioneye',
+                url: selectedOption.attr('data-connection-url') || ''
+            });
         }
         else {
             this._prevSelectedIndex = this.selectedIndex;
@@ -822,6 +832,20 @@ function initUI() {
 
     /* remove camera button */
     $('div.button.rem-camera-button').on('click', doRemCamera);
+
+    /* edit camera credentials button */
+    $('div#editCredentialsButton').on('click', function () {
+        var cameraId = $('#cameraSelect').val();
+        var proto = $('#deviceTypeEntry')[0].proto;
+        var url = $('#deviceUrlEntry').val();
+
+        if (proto == 'mjpeg') {
+            var cameraFrame = getCameraFrame(cameraId);
+            url = cameraFrame.length ? cameraFrame[0].config.url : '';
+        }
+
+        runEditCredentialsDialog(cameraId, {proto: proto, url: url});
+    });
 
     /* logout button */
     $('div.button.logout-button').on('click', doLogout);
@@ -2096,6 +2120,7 @@ function dict2CameraUi(dict) {
     $('#deviceUrlEntry').val(dict['device_url']); markHideIfNull('device_url', 'deviceUrlEntry');
     $('#deviceTypeEntry').val(prettyType); markHideIfNull(!prettyType, 'deviceTypeEntry');
     $('#deviceTypeEntry')[0].proto = dict['proto'];
+    markHideIfNull(!['netcam', 'mjpeg'].includes(dict['proto']), 'editCredentialsButton');
     $('#adminOnlySwitch')[0].checked = dict['admin_only']; markHideIfNull('admin_only', 'adminOnlySwitch');
     $('#autoBrightnessSwitch')[0].checked = dict['auto_brightness']; markHideIfNull('auto_brightness', 'autoBrightnessSwitch');
 
@@ -3225,7 +3250,13 @@ function fetchCurrentConfig(onFetch) {
                 cameraSelect.html('');
                 for (i = 0; i < cameras.length; i++) {
                     var camera = cameras[i];
-                    cameraSelect.append('<option value="' + camera['id'] + '">' + camera['name'] + '</option>');
+                    var option = $('<option>').val(camera.id).text(camera.name);
+                    if (camera['connection_failed']) {
+                        option.attr('data-connection-failed', 'true');
+                        option.attr('data-connection-error', camera['connection_error'] || '');
+                        option.attr('data-connection-url', camera['connection_url'] || '');
+                    }
+                    cameraSelect.append(option);
                 }
 
                 if (!query.camera_ids) {
@@ -3323,6 +3354,12 @@ function fetchCurrentCameraConfig(onFetch) {
             if (data == null || data.error) {
                 showErrorMessage(data && data.error);
                 dict2CameraUi(null);
+                if (data && data.connection_failed && isAdmin()) {
+                    runEditCredentialsDialog(cameraId, {
+                        proto: 'motioneye',
+                        url: data.connection_url || ''
+                    });
+                }
                 if (onFetch) {
                     onFetch(null);
                 }
@@ -4099,6 +4136,97 @@ function runAddCameraDialog() {
     });
 
     updateUi();
+}
+
+function runEditCredentialsDialog(cameraId, data) {
+    if (Object.keys(pushConfigs).length) {
+        return runAlertDialog(i18n.gettext("Bonvolu apliki unue la modifitajn agordojn!"));
+    }
+
+    var rows =
+        '<tr>' +
+            '<td class="dialog-item-label"><span class="dialog-item-label">'+i18n.gettext("URL")+'</span></td>' +
+            '<td class="dialog-item-value"><input type="text" class="styled" id="urlEntry" placeholder="'+i18n.gettext("http://ekzemplo.com:8765/cams/...")+'"></td>' +
+            '<td><span class="help-mark" title="'+i18n.gettext("la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)")+'">?</span></td>' +
+        '</tr>';
+
+    if (data.proto == 'netcam') {
+        rows +=
+            '<tr>' +
+                '<td class="dialog-item-label"><span class="dialog-item-label">'+i18n.gettext("Uzantnomo")+'</span></td>' +
+                '<td class="dialog-item-value"><input type="text" class="styled" id="usernameEntry" placeholder="'+i18n.gettext("uzantnomo...")+'"></td>' +
+                '<td><span class="help-mark" title="'+i18n.gettext("leave both empty to keep the current username and password")+'">?</span></td>' +
+            '</tr>' +
+            '<tr>' +
+                '<td class="dialog-item-label"><span class="dialog-item-label">'+i18n.gettext("Pasvorto")+'</span></td>' +
+                '<td class="dialog-item-value"><input type="password" class="styled" id="passwordEntry" placeholder="'+i18n.gettext("pasvorto...")+'"></td>' +
+                '<td><span class="help-mark" title="'+i18n.gettext("leave both empty to keep the current username and password")+'">?</span></td>' +
+            '</tr>';
+    }
+    else if (data.proto == 'motioneye') {
+        rows +=
+            '<tr>' +
+                '<td class="dialog-item-label"><span class="dialog-item-label">'+i18n.gettext("Remote Secret")+'</span></td>' +
+                '<td class="dialog-item-value"><input type="password" class="styled" id="remoteSecretDialogEntry" placeholder="'+i18n.gettext("remote secret...")+'"></td>' +
+                '<td><span class="help-mark" title="'+i18n.gettext("leave empty to keep the current remote secret")+'">?</span></td>' +
+            '</tr>';
+    }
+
+    var content = $('<table class="edit-credentials-dialog">' + rows + '</table>');
+    var urlEntry = content.find('#urlEntry');
+    var usernameEntry = content.find('#usernameEntry');
+    var passwordEntry = content.find('#passwordEntry');
+    var remoteSecretDialogEntry = content.find('#remoteSecretDialogEntry');
+
+    urlEntry.val(data.url || '');
+
+    makeUrlValidator(urlEntry);
+
+    runModalDialog({
+        title: i18n.gettext('Edit connection information'),
+        closeButton: true,
+        buttons: 'okcancel',
+        content: content,
+        onOk: function () {
+            if (!urlEntry[0].validate()) {
+                return false;
+            }
+
+            var payload = {url: urlEntry.val()};
+
+            if (data.proto == 'netcam') {
+                if (usernameEntry.val()) {
+                    payload.username = usernameEntry.val();
+                }
+                if (passwordEntry.val()) {
+                    payload.password = passwordEntry.val();
+                }
+            }
+            else if (data.proto == 'motioneye' && remoteSecretDialogEntry.val()) {
+                payload.remote_secret = remoteSecretDialogEntry.val();
+            }
+
+            beginProgress();
+            ajax('POST', basePath + 'config/' + cameraId + '/credentials/', payload, function (resp) {
+                endProgress();
+
+                if (resp == null || resp.error) {
+                    showErrorMessage(resp && resp.error);
+                    return;
+                }
+
+                if (data.proto == 'motioneye') {
+                    fetchCurrentConfig();
+                }
+                else if (data.proto == 'mjpeg') {
+                    recreateCameraFrames();
+                }
+                else {
+                    $('#cameraSelect').trigger('change');
+                }
+            });
+        }
+    });
 }
 
 function runTimelapseDialog(cameraId, groupKey, group) {

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -297,6 +297,11 @@
                             <td class="settings-item-value"><input type="text" class="styled device camera-config" id="deviceTypeEntry" readonly="readonly"></td>
                         </tr>
                         <tr class="settings-item">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Connection") }}</span></td>
+                            <td class="settings-item-value"><div class="button normal-button edit-credentials-button" id="editCredentialsButton">{{ _("Edit Credentials") }}</div></td>
+                            <td><span class="help-mark" title="{{ _("edit the camera URL and credentials") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Admin-only access") }}</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled device camera-config" id="adminOnlySwitch"></td>
                             <td><span class="help-mark" title="{{ _("If enabled only the admin user can access this camera") }}">?</span></td>


### PR DESCRIPTION
Adds a dedicated dialog for editing camera connection information and credentials, so users no longer need to manually edit configuration files or remove and re-add a camera when a password, URL, or remote secret changes.

Admins can now update:
- network camera URL, username, and password
- simple MJPEG camera URL
- remote motionEye URL and remote secret

##

This adds a new credentials update endpoint: `POST /config/<camera_id>/credentials/`. The endpoint updates only camera connection data instead of going through the full camera settings form. It also allows updating the local configuration of a remote motionEye camera when the remote configuration cannot be loaded.

For remote motionEye and simple MJPEG cameras, Motion does not need to be restarted for changes to take effect. For network cameras that go through the local Motion process, Motion is restarted after saving so the updated connection settings take effect.

For network cameras, the dialog can update the URL, username, and password. Leaving both username and password blank preserves the current username and password. Username and password encoding is shared with the add-camera flow through a new helper.

For simple MJPEG cameras, the dialog updates the stored URL and recreates the camera frames after saving so the stream immediately uses the new URL.
(Note: the add-camera dialog currently asks for an optional username and password for simple MJPEG cameras, but AFAICS those values are not currently stored for that camera type.)

For remote motionEye cameras, failed connections are shown in the camera selector as `Camera <id> - Connection failed`. When a failed camera is selected from the dropdown, the edit dialog opens automatically so the connection details can be corrected. If there are no enabled cameras and the first camera in the list is a failed remote motionEye camera, the edit dialog is shown automatically (after attempting to load the camera configuration) together with the error message. After saving, the camera configuration is refreshed so the remote camera can appear normally again if the connection succeeds.

The edit dialog needs the current remote motionEye URL because it is prefilled. When the connection fails, that URL of course cannot be read from the remote config, so failed camera-list entries and failed config responses now include the remote base URL from the local camera config together with the existing error message for the dialog to use.