### PR TITLE
handlers: require authentication for prefs API

### DIFF
--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -22,7 +22,7 @@ from time import time
 
 from tornado.web import HTTPError, RequestHandler
 
-from motioneye import config, prefs, settings, template, utils
+from motioneye import config, settings, template, utils
 from motioneye.utils.authstate import verify_hmac_signature
 
 __all__ = ('BaseHandler', 'NotFoundHandler', 'ManifestHandler')
@@ -190,12 +190,6 @@ class BaseHandler(RequestHandler):
                 return None
 
         return None
-
-    def get_pref(self, key):
-        return prefs.get(self.current_user or 'anonymous', key)
-
-    def set_pref(self, key, value):
-        return prefs.set(self.current_user or 'anonymous', key, value)
 
     def _handle_request_exception(self, exception):
         try:

--- a/motioneye/handlers/prefs.py
+++ b/motioneye/handlers/prefs.py
@@ -18,15 +18,18 @@
 import json
 import logging
 
+from motioneye import prefs
 from motioneye.handlers.base import BaseHandler
 
 __all__ = ('PrefsHandler',)
 
 
 class PrefsHandler(BaseHandler):
+    @BaseHandler.auth()
     def get(self, key=None):
-        self.finish_json(self.get_pref(key))
+        self.finish_json(prefs.get(self.current_user, key))
 
+    @BaseHandler.auth()
     def post(self, key=None):
         try:
             value = json.loads(self.request.body)
@@ -36,4 +39,4 @@ class PrefsHandler(BaseHandler):
 
             raise
 
-        self.set_pref(key, value)
+        prefs.set(self.current_user, key, value)

--- a/motioneye/handlers/prefs.py
+++ b/motioneye/handlers/prefs.py
@@ -17,6 +17,7 @@
 
 import json
 import logging
+from typing import Dict, Union
 
 from motioneye import prefs
 from motioneye.handlers.base import BaseHandler
@@ -26,17 +27,20 @@ __all__ = ('PrefsHandler',)
 
 class PrefsHandler(BaseHandler):
     @BaseHandler.auth()
-    def get(self, key=None):
+    def get(self, key: Union[str, None] = None) -> None:
         self.finish_json(prefs.get(self.current_user, key))
 
     @BaseHandler.auth()
-    def post(self, key=None):
+    def post(self, key: Union[str, None] = None) -> None:
         try:
-            value = json.loads(self.request.body)
+            PrefsValue = Union[int, float, bool]
+            value: Union[Dict[str, PrefsValue], PrefsValue] = json.loads(
+                self.request.body
+            )
 
         except Exception as e:
-            logging.error('could not decode json: %s' % e)
+            logging.error(f'could not decode json: {e}')
 
             raise
 
-        prefs.set(self.current_user, key, value)
+        prefs.set(self.current_user, value, key)

--- a/motioneye/prefs.py
+++ b/motioneye/prefs.py
@@ -17,11 +17,15 @@
 import json
 import logging
 import os.path
+from typing import Dict, Union, cast
 
 from motioneye import settings
 
-_PREFS_FILE_NAME = 'prefs.json'
-_DEFAULT_PREFS = {
+PrefsValue = Union[int, float, bool]
+PrefsDict = Dict[str, PrefsValue]
+
+_PREFS_FILE_NAME: str = 'prefs.json'
+_DEFAULT_PREFS: PrefsDict = {
     'layout_columns': 3,
     'fit_frames_vertically': True,
     'layout_rows': 1,
@@ -29,18 +33,16 @@ _DEFAULT_PREFS = {
     'resolution_factor': 1,
 }
 
-_prefs = None
+_prefs: Dict[str, PrefsDict] = {}
 
 
-def _load():
+def _load() -> None:
     global _prefs
 
-    _prefs = {}
-
-    file_path = os.path.join(settings.CONF_PATH, _PREFS_FILE_NAME)
+    file_path: str = os.path.join(settings.CONF_PATH, _PREFS_FILE_NAME)
 
     if os.path.exists(file_path):
-        logging.debug('loading preferences from "%s"...' % file_path)
+        logging.debug(f'loading preferences from "{file_path}"...')
 
         try:
             f = open(file_path)
@@ -61,15 +63,14 @@ def _load():
 
     else:
         logging.debug(
-            'preferences file "%s" does not exist, using default preferences'
-            % file_path
+            f'preferences file "{file_path}" does not exist, using default preferences'
         )
 
 
-def _save():
-    file_path = os.path.join(settings.CONF_PATH, _PREFS_FILE_NAME)
+def _save() -> None:
+    file_path: str = os.path.join(settings.CONF_PATH, _PREFS_FILE_NAME)
 
-    logging.debug('saving preferences to "%s"...' % file_path)
+    logging.debug(f'saving preferences to "{file_path}"...')
 
     try:
         f = open(file_path, 'w')
@@ -89,28 +90,29 @@ def _save():
         f.close()
 
 
-def get(username, key=None):
-    if _prefs is None:
+def get(
+    username: str, key: Union[str, None] = None
+) -> Union[PrefsDict, PrefsValue, None]:
+    if not _prefs:
         _load()
 
     if key:
-        prefs = _prefs.get(username, {}).get(key, _DEFAULT_PREFS.get(key))
+        return _prefs.get(username, {}).get(key, _DEFAULT_PREFS.get(key))
 
     else:
-        prefs = dict(_DEFAULT_PREFS)
-        prefs.update(_prefs.get(username, {}))
-
-    return prefs
+        return {**_DEFAULT_PREFS, **_prefs.get(username, {})}
 
 
-def set(username, key, value):
-    if _prefs is None:
+def set(
+    username: str, value: Union[PrefsDict, PrefsValue], key: Union[str, None] = None
+) -> None:
+    if not _prefs:
         _load()
 
     if key:
-        _prefs.setdefault(username, {})[key] = value
+        _prefs.setdefault(username, {})[key] = cast(PrefsValue, value)
 
     else:
-        _prefs[username] = value
+        _prefs[username] = cast(PrefsDict, value)
 
     _save()

--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -378,7 +378,9 @@ div.normal-button {
     font-size: 0.9em;
     border-radius: 3px;
     transition: all 0.1s linear;
-    width: 8em;
+    min-width: 7em;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
 }
 
 div.update-button,


### PR DESCRIPTION
This API is harmless, affects visual preferences only: camera frame alignment and sizes, as well as lowering the displayed camera resolution and framerate.

However, this matters only for the GUI after authentication, hence there is no point to allow using this API without authentication, messing with users' preferences.

For clarity, the functions for getting/setting prefs have been moved into the prefs handler script, and inlined, since they are used only ín this single place.

Since I am lazy to create two PRs, this commit additionally allows the blue settings panel buttons to grow with long text. With some translations, they can be too small. The fixed width is turned into a minimal width with a padding. Buttons with short texts will have the same size, but buttons with longer text will grow with the text length.

<img width="406" height="300" alt="{8CF2F25C-9413-4889-982D-ACF2BA2288AE}" src="https://github.com/user-attachments/assets/764d8d62-28e6-4450-a6bc-0dd86617254f" />