### PR TITLE
fix: restore Python 3.7 compatibility

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -15,11 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
+          # Tests with oldest Python version able to build the project on oldest available runner images
+          - { dist: 'ubuntu-22.04', python: '3.9' }
+          - { dist: 'ubuntu-22.04-arm', python: '3.9' }
           # https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=python3
           - { dist: 'ubuntu-22.04', python: '3.10.6' }
           - { dist: 'ubuntu-24.04', python: '3.12.3' }
+          # No Python 3.14 supported for ubuntu-26.04 runners yet: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+          - { dist: 'ubuntu-24.04', python: '3.14.3' }
           - { dist: 'ubuntu-22.04-arm', python: '3.10.6' }
           - { dist: 'ubuntu-24.04-arm', python: '3.12.3' }
+          - { dist: 'ubuntu-24.04-arm', python: '3.14.3' }
       fail-fast: false
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     strategy:
       matrix:
-        dist: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
+        dist: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm', 'ubuntu-26.04-arm']
       fail-fast: false
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@
 # `brew install pre-commit` or `python3 -m pip install pre-commit`
 # Then in the project root directory run `pre-commit install`
 
-# default_language_version:
-#   python: python3.10
+default_language_version:
+  python: python3.14
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -23,13 +23,19 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
-        args:
-          - --skip=B104,B105,B108,B110,B301,B310,B321,B324,B402,B403,B404,B602,B603,B604,B605,B607,B701
-  - repo: https://github.com/python/black
+        args: ["--skip=B104,B105,B108,B110,B301,B310,B321,B402,B403,B404,B602,B603,B604,B605,B607,B701"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.18
+    hooks:
+      - id: ruff-check
+        args: [--target-version=py37, --ignore, E722, --config, "builtins = ['_']"]
+      - id: ruff-format
+        args: [--target-version=py37, --config, "format.quote-style = 'preserve'"]
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.5.1
     hooks:
       - id: black
-        args: [--skip-string-normalization]
+        args: [--skip-string-normalization, -t, py37, -t, py38, -t, py39, -t, py310, -t, py311, -t, py312, -t, py313, -t, py314]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:
@@ -40,6 +46,7 @@ repos:
     hooks:
       - id: flake8
         # Skipped plugins which are currently not used by "--select": flake8-return, which does not support Python 3.14 yet: https://github.com/afonasev/flake8-return/pull/139
+        # R501,R502,R503,R504,R505,R506,R507,R508
         additional_dependencies: [flake8-2020, flake8-bugbear, flake8-comprehensions]
         args:
           - --builtins=_
@@ -53,7 +60,7 @@ repos:
     rev: 9.0.0a3
     hooks:
       - id: isort
-        args: ["--profile", "black", "--filter-files"]
+        args: [--profile, black, --filter-files]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,5 @@
 """Pytest configuration."""
 
-import pytest
-
 
 def pytest_collection_modifyitems(config, items):
     """Modify collected test items to exclude non-test functions from source files."""

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -29,6 +29,7 @@ from re import match, sub
 from secrets import token_hex
 from shlex import split
 from stat import S_IMODE
+from typing import Optional
 from urllib.parse import quote, urlunparse
 
 from argon2 import PasswordHasher
@@ -193,7 +194,7 @@ _MOTION_43_TO_41_OPTIONS_MAPPING = {
 
 def netcam_keepalive_params(v, data):
     # value can be 'force' as well
-    v = 'on' if v == True else 'off' if v == False else v
+    v = 'on' if v == True else 'off' if v == False else v  # noqa: E712
 
     if 'netcam_params' in data and data['netcam_params']:
         return {'netcam_params': data['netcam_params'] + ',keepalive = ' + v}
@@ -2106,7 +2107,7 @@ def invalidate_monitor_commands():
     _monitor_command_cache.clear()
 
 
-def backup() -> bytes | None:
+def backup() -> Optional[bytes]:
     logging.debug('generating config backup file')
 
     files = [
@@ -2131,7 +2132,7 @@ def backup() -> bytes | None:
         return None
 
 
-def restore(content: bytes) -> dict | None:
+def restore(content: bytes) -> Optional[dict]:
     logging.info('restoring config from backup file')
 
     patterns = ['motion.conf', 'camera-*.conf', 'mask_*.pgm', 'prefs.json']

--- a/motioneye/controls/tzctl.py
+++ b/motioneye/controls/tzctl.py
@@ -48,7 +48,7 @@ def _get_time_zone_symlink():
 
     time_zone = f or None
     if time_zone:
-        logging.debug('found time zone by symlink method: %s' % time_zone)
+        logging.debug(f'found time zone by symlink method: {time_zone}')
 
     return time_zone
 
@@ -63,12 +63,12 @@ def _get_time_zone_md5():
         )
 
     except Exception as e:
-        logging.error('getting md5 of zoneinfo files failed: %s' % e)
+        logging.error(f'getting md5 of zoneinfo files failed: {e}')
 
         return None
 
-    lines = [l for l in output.split('\n') if l]
-    lines = [l.split(None, 1) for l in lines]
+    lines = [line for line in output.split('\n') if line]
+    lines = [line.split(None, 1) for line in lines]
     time_zone_by_md5 = dict(lines)
 
     try:
@@ -76,15 +76,15 @@ def _get_time_zone_md5():
             data = f.read()
 
     except Exception as e:
-        logging.error('failed to read local time file: %s' % e)
+        logging.error(f'failed to read local time file: {e}')
 
         return None
 
-    md5 = hashlib.md5(data).hexdigest()
+    md5 = hashlib.md5(data).hexdigest()  # nosec: B324
     time_zone = time_zone_by_md5.get(md5)
 
     if time_zone:
-        logging.debug('found time zone by md5 method: %s' % time_zone)
+        logging.debug(f'found time zone by md5 method: {time_zone}')
 
     return time_zone
 
@@ -94,7 +94,7 @@ def _set_time_zone(time_zone):
 
     zoneinfo_file = '/usr/share/zoneinfo/' + time_zone
     if not os.path.exists(zoneinfo_file):
-        logging.error('%s file does not exist' % zoneinfo_file)
+        logging.error(f'{zoneinfo_file} file does not exist')
 
         return False
 

--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -14,13 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import fcntl
 import logging
 import os.path
 import re
 import stat
 import subprocess
-import time
 from shlex import quote
 
 from motioneye import utils
@@ -87,7 +85,6 @@ def list_resolutions(device):
 
     resolutions = set()
     output = b''
-    started = time.time()
     cmd = f"v4l2-ctl -d {quote(device)} --list-formats-ext | grep -vi stepwise | grep -oE '[0-9]+x[0-9]+' || true"
     logging.debug(f'running command "{cmd}"')
 
@@ -168,7 +165,6 @@ def list_ctrls(device):
         return _ctrls_cache[device]
 
     output = b''
-    started = time.time()
     cmd = ['v4l2-ctl', '-d', device, '--list-ctrls']
     logging.debug(f'running command "{" ".join(cmd)}"')
 

--- a/motioneye/handlers/base.py
+++ b/motioneye/handlers/base.py
@@ -22,7 +22,7 @@ from time import time
 
 from tornado.web import HTTPError, RequestHandler
 
-from motioneye import config, settings, template, utils
+from motioneye import config, template
 from motioneye.utils.authstate import verify_hmac_signature
 
 __all__ = ('BaseHandler', 'NotFoundHandler', 'ManifestHandler')

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -18,7 +18,6 @@
 import datetime
 import json
 import logging
-import os
 import socket
 from urllib.parse import urlparse
 

--- a/motioneye/handlers/login.py
+++ b/motioneye/handlers/login.py
@@ -18,6 +18,7 @@
 import logging
 from hashlib import sha1
 from secrets import compare_digest
+from typing import Any, Dict
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchError
@@ -25,6 +26,7 @@ from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchErro
 from motioneye import config
 from motioneye.handlers.base import BaseHandler, create_session
 from motioneye.utils.authstate import (
+    PasswordHashState,
     build_password_hash_state,
     mark_user_migrated,
     set_password_hash_state,
@@ -43,7 +45,7 @@ def verify_argon2_password(stored_hash, plaintext_password):
 
 
 def verify_legacy_sha1_password(stored_hash, plaintext_password):
-    candidate = sha1(plaintext_password.encode()).hexdigest()
+    candidate = sha1(plaintext_password.encode()).hexdigest()  # nosec B324
     return compare_digest(candidate, stored_hash)
 
 
@@ -56,7 +58,7 @@ def should_use_secure_cookie(handler):
 
 class LoginHandler(BaseHandler):
     @BaseHandler.auth()
-    def get(self):
+    def get(self) -> None:
         user = self.current_user
         if user:
             main_config = config.get_main()
@@ -70,7 +72,7 @@ class LoginHandler(BaseHandler):
             self.set_status(401)
             self.finish_json({'error': 'not authenticated'})
 
-    def post(self):
+    def post(self) -> None:
         body = self.get_json() or {}
         username: str = self.get_argument('username', body.get('username') or '')
         password: str = self.get_argument('password', body.get('password') or '')
@@ -82,7 +84,7 @@ class LoginHandler(BaseHandler):
         main_config: dict = config.get_main()
 
         # Always rebuild from current config so hash state is not stale
-        hash_state: str = build_password_hash_state(main_config)
+        hash_state: PasswordHashState = build_password_hash_state(main_config)
         set_password_hash_state(hash_state)
 
         user_type: str
@@ -147,7 +149,7 @@ class LoginHandler(BaseHandler):
             samesite='Strict',
         )
 
-        response = {'user': user_type}
+        response: Dict[str, Any] = {'user': user_type}
 
         if hash_type == 'missing':
             response['force_password_change'] = True

--- a/motioneye/handlers/logout.py
+++ b/motioneye/handlers/logout.py
@@ -15,20 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from motioneye.handlers.base import (
-    BaseHandler,
-    invalidate_session,
-    invalidate_user_sessions,
-)
+from motioneye.handlers.base import BaseHandler, invalidate_session
 
 __all__ = ('LogoutHandler',)
 
 
 class LogoutHandler(BaseHandler):
     def post(self):
-        # Get current user info
-        user = self.current_user
-
         # Clear the session cookie
         self.clear_cookie('user')
 

--- a/motioneye/handlers/movie.py
+++ b/motioneye/handlers/movie.py
@@ -17,6 +17,7 @@
 
 import logging
 from os.path import join
+from typing import Optional
 
 from tornado.web import HTTPError
 
@@ -27,7 +28,7 @@ __all__ = ('MovieHandler',)
 
 
 class MovieHandler(BaseHandler):
-    async def get(self, camera_id: str, op, filename: str | None = None):
+    async def get(self, camera_id: str, op, filename: Optional[str] = None):
         camera_id = int(camera_id)  # type: ignore[assignment]
         if camera_id not in config.get_camera_ids():
             raise HTTPError(404, 'no such camera')
@@ -64,7 +65,11 @@ class MovieHandler(BaseHandler):
             raise HTTPError(400, 'unknown operation')
 
     async def post(
-        self, camera_id: str, op, filename: str | None = None, group: str | None = None
+        self,
+        camera_id: str,
+        op,
+        filename: Optional[str] = None,
+        group: Optional[str] = None,
     ):
         camera_id = int(camera_id)  # type: ignore[assignment]
         if camera_id not in config.get_camera_ids():

--- a/motioneye/handlers/picture.py
+++ b/motioneye/handlers/picture.py
@@ -18,6 +18,7 @@
 import logging
 from os.path import basename, join
 from re import sub
+from typing import Optional
 
 from tornado import gen
 from tornado.web import HTTPError
@@ -42,7 +43,11 @@ class PictureHandler(BaseHandler):
         return None
 
     async def get(
-        self, camera_id: str, op, filename: str | None = None, group: str | None = None
+        self,
+        camera_id: str,
+        op,
+        filename: Optional[str] = None,
+        group: Optional[str] = None,
     ):
         camera_id = int(camera_id)  # type: ignore[assignment]
         if camera_id not in config.get_camera_ids():
@@ -99,7 +104,11 @@ class PictureHandler(BaseHandler):
             raise HTTPError(400, 'unknown operation')
 
     async def post(
-        self, camera_id: str, op, filename: str | None = None, group: str | None = None
+        self,
+        camera_id: str,
+        op,
+        filename: Optional[str] = None,
+        group: Optional[str] = None,
     ):
         camera_id = int(camera_id)  # type: ignore[assignment]
         if camera_id not in config.get_camera_ids():

--- a/motioneye/handlers/relay_event.py
+++ b/motioneye/handlers/relay_event.py
@@ -17,6 +17,7 @@
 
 import logging
 from os import sep
+from typing import Optional
 
 from motioneye import config, mediafiles, motionctl, tasks, uploadservices, utils
 from motioneye.handlers.base import BaseHandler
@@ -69,7 +70,7 @@ class RelayEventHandler(BaseHandler):
             self.finish_json()
             return
 
-        filename: str | None = self.get_argument('filename')
+        filename: Optional[str] = self.get_argument('filename')
         if filename is not None:
             target_dir: str = camera_config['target_dir']
             utils.validate_paths(

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:956
+#: motioneye/config.py:957
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:960
+#: motioneye/config.py:961
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:965
+#: motioneye/config.py:966
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:970
+#: motioneye/config.py:971
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:975
+#: motioneye/config.py:976
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -22,13 +22,13 @@ import multiprocessing
 import os.path
 import re
 import subprocess
-import typing
 from errno import EAGAIN, ENOENT
 from hashlib import sha1
 from io import BytesIO
 from shlex import quote
 from signal import SIGKILL, SIGTERM
 from time import time
+from typing import Awaitable, List, Optional
 from zipfile import ZipFile
 
 from PIL import Image
@@ -106,10 +106,10 @@ _ffmpeg_binary_cache = None
 
 def _list_media_files(
     base_path: str,
-    exts: typing.List[str],
-    sub_path: str | None = None,
+    exts: List[str],
+    sub_path: Optional[str] = None,
     with_stat: bool = True,
-) -> typing.List[tuple]:
+) -> List[tuple]:
     # Determine scan path based on sub_path parameter
     if sub_path is not None:
         if sub_path == 'ungrouped':
@@ -156,7 +156,7 @@ def _remove_older_files(
     directory: str,
     moment: datetime.datetime,
     clean_cloud_info: dict,
-    exts: typing.List[str],
+    exts: List[str],
 ):
     removed_folder_count = 0
     for full_path, st in _list_media_files(directory, exts, with_stat=True):
@@ -181,7 +181,7 @@ def _remove_older_files(
                 continue
 
             listing = os.listdir(dir_path)
-            thumbs = [l for l in listing if l.endswith('.thumb')]
+            thumbs = [line for line in listing if line.endswith('.thumb')]
 
             if len(listing) == len(thumbs):  # only thumbs
                 for p in thumbs:
@@ -331,7 +331,7 @@ def find_ffmpeg() -> tuple:
         return None, None, None
 
     lines = output.split('\n')
-    lines = [l for l in lines if re.match('^ [DEVILSA.]{6} [^=].*', l)]
+    lines = [line for line in lines if re.match('^ [DEVILSA.]{6} [^=].*', line)]
 
     codecs = {}
     for line in lines:
@@ -446,7 +446,7 @@ def get_movie_duration_seconds(path: str) -> int:
         return 0
 
 
-def make_movie_preview(camera_config: dict, full_path: str) -> typing.Union[str, None]:
+def make_movie_preview(camera_config: dict, full_path: str) -> Optional[str]:
     framerate = camera_config['framerate']
     pre_capture = camera_config['pre_capture']
     offs = pre_capture / framerate
@@ -528,9 +528,9 @@ def make_movie_preview(camera_config: dict, full_path: str) -> typing.Union[str,
 def list_media(
     camera_config: dict,
     media_type: str,
-    prefix: str | None = None,
+    prefix: Optional[str] = None,
     with_stat: bool = True,
-) -> typing.Awaitable:
+) -> Awaitable:
     target_dir = camera_config.get('target_dir')
     utils.validate_paths(prefix, target_dir=target_dir)
 
@@ -612,9 +612,7 @@ def get_media_content(camera_config, path: str, media_type):
         return None
 
 
-def get_zipped_content(
-    camera_config: dict, media_type: str, group: str
-) -> typing.Awaitable:
+def get_zipped_content(camera_config: dict, media_type: str, group: str) -> Awaitable:
     target_dir = camera_config.get('target_dir')
     utils.validate_paths(group, target_dir=target_dir)
 
@@ -828,7 +826,7 @@ def make_timelapse_movie(camera_config, framerate, interval, group: str):
 
                 raise
 
-            frame_index = re.findall(br'frame=\s*(\d+)', output)
+            frame_index = re.findall(rb'frame=\s*(\d+)', output)
             try:
                 frame_index = int(frame_index[-1])
 
@@ -967,7 +965,7 @@ def del_media_content(camera_config, path: str, media_type):
         # remove the parent directories if empty or contains only thumb files
         dir_path = os.path.dirname(full_path)
         listing = os.listdir(dir_path)
-        thumbs = [l for l in listing if l.endswith('.thumb')]
+        thumbs = [line for line in listing if line.endswith('.thumb')]
 
         if len(listing) == len(thumbs):  # only thumbs
             for p in thumbs:
@@ -1008,7 +1006,7 @@ def del_media_group(camera_config, group: str, media_type):
 
     # remove the group directory if empty or contains only thumb files
     listing = os.listdir(full_path)
-    thumbs = [l for l in listing if l.endswith('.thumb')]
+    thumbs = [line for line in listing if line.endswith('.thumb')]
 
     if len(listing) == len(thumbs):  # only thumbs
         for p in thumbs:
@@ -1069,7 +1067,7 @@ def get_prepared_cache(key):
 
 
 def set_prepared_cache(data):
-    key = sha1(str(time()).encode()).hexdigest()  # nosec B303
+    key = sha1(str(time()).encode()).hexdigest()  # nosec B303, B324
 
     if key in _prepared_files:
         logging.warning(f'key "{key}" already present in prepared cache')

--- a/motioneye/meyectl.py
+++ b/motioneye/meyectl.py
@@ -209,7 +209,7 @@ def configure_logging(cmd, log_to_file=False):
         fmt = f'%(asctime)s: [{cmd}] %(levelname)8s: %(message)s'
 
     else:
-        fmt = f'%(levelname)8s: %(message)s'
+        fmt = '%(levelname)8s: %(message)s'
 
     for h in logging.getLogger().handlers:
         logging.getLogger().removeHandler(h)

--- a/motioneye/mjpgclient.py
+++ b/motioneye/mjpgclient.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 from errno import ECONNREFUSED
 from re import findall, match
 from time import time
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
@@ -186,13 +186,13 @@ class MjpgClient(IOStream):
 
         self._seek_http()
 
-    def _seek_http(self, future: Future | None = None) -> None:
+    def _seek_http(self, future: Optional[Future] = None) -> None:
         result, _ = self._get_future_result(future) if future else (True, False)
 
         if not result or self._check_error():
             return
 
-        future = utils.cast_future(self.read_until_regex(br'HTTP/1.\d \d+ '))
+        future = utils.cast_future(self.read_until_regex(rb'HTTP/1.\d \d+ '))
         future.add_done_callback(self._on_http)
 
     def _on_http(self, future: Future) -> None:
@@ -225,7 +225,7 @@ class MjpgClient(IOStream):
 
         data = data.strip()
 
-        m = match(br'Basic\s*realm="([a-zA-Z0-9\-\s]+)"', data)
+        m = match(rb'Basic\s*realm="([a-zA-Z0-9\-\s]+)"', data)
         if m:
             logging.debug('mjpg client using basic authentication')
 

--- a/motioneye/remote.py
+++ b/motioneye/remote.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 from time import time
-from typing import Union
+from typing import Optional
 from urllib.parse import urlencode
 
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPResponse
@@ -86,7 +86,6 @@ async def _send_request(request: HTTPRequest) -> HTTPResponse:
         response = await AsyncHTTPClient().fetch(request, raise_error=False)
 
         if response.code != 200:
-
             decoded = json.loads(response.body)
             if decoded['error'] == 'unauthorized':
                 response.error = Exception('Authentication Error')
@@ -249,7 +248,7 @@ async def get_config(local_config) -> utils.GetConfigResponse:
         return utils.GetConfigResponse(remote_ui_config=response, error=None)
 
 
-async def set_config(local_config, ui_config) -> Union[str, None]:
+async def set_config(local_config, ui_config) -> Optional[str]:
     scheme = local_config.get('@scheme', local_config.get('scheme'))
     host = local_config.get('@host', local_config.get('host'))
     port = local_config.get('@port', local_config.get('port'))
@@ -388,7 +387,7 @@ async def get_current_picture(
 
 
 async def list_media(
-    local_config, media_type, prefix: str | None = None
+    local_config, media_type, prefix: Optional[str] = None
 ) -> utils.ListMediaResponse:
     utils.validate_paths(prefix)
 

--- a/motioneye/sendtelegram.py
+++ b/motioneye/sendtelegram.py
@@ -65,7 +65,6 @@ def make_message(message, camera_id, moment, timespan, callback):
 
     def on_media_files(media_files):
         io_loop.stop()
-        photos = []
 
         timestamp = time.mktime(moment.timetuple())
         if media_files:

--- a/motioneye/server.py
+++ b/motioneye/server.py
@@ -281,28 +281,28 @@ def test_requirements():
             sys.exit(-1)
 
     try:
-        import tornado  # @UnusedImport
+        import tornado  # noqa: F401
 
     except ImportError:
         logging.fatal(_('bonvolu instali tornado version 3.1 aŭ pli'))
         sys.exit(-1)
 
     try:
-        import jinja2  # @UnusedImport
+        import jinja2  # noqa: F401
 
     except ImportError:
         logging.fatal(_('bonvolu instali jinja2'))
         sys.exit(-1)
 
     try:
-        import PIL.Image  # @UnusedImport
+        import PIL.Image  # noqa: F401
 
     except ImportError:
         logging.fatal(_('bonvolu instali pillow aŭ PIL'))
         sys.exit(-1)
 
     try:
-        import pycurl  # @UnusedImport
+        import pycurl  # noqa: F401
 
     except ImportError:
         logging.fatal(_('bonvolu instali pycurl'))

--- a/motioneye/tasks.py
+++ b/motioneye/tasks.py
@@ -21,6 +21,7 @@ import multiprocessing
 import os
 import pickle
 import time
+from typing import List
 
 from tornado.ioloop import IOLoop
 
@@ -34,7 +35,7 @@ _MAX_TASKS = 100
 # TODO replace the pool with one simple thread
 _POOL_SIZE = 1
 
-_tasks: list[tuple] = []
+_tasks: List[tuple] = []
 _pool = None
 
 
@@ -64,7 +65,7 @@ def stop():
 def add(when, func, tag=None, callback=None, **params):
     if len(_tasks) >= _MAX_TASKS:
         return logging.error(
-            'the maximum number of tasks (%d) has been reached' % _MAX_TASKS
+            f'the maximum number of tasks ({_MAX_TASKS}) has been reached'
         )
 
     now = time.time()
@@ -82,7 +83,7 @@ def add(when, func, tag=None, callback=None, **params):
     while i < len(_tasks) and _tasks[i][0] <= when:
         i += 1
 
-    logging.debug('adding task "%s" in %d seconds' % (tag or func.__name__, when - now))
+    logging.debug(f'adding task "{tag or func.__name__}" in {when - now} seconds')
     _tasks.insert(i, (when, func, tag, callback, params))
 
     _save()
@@ -97,7 +98,7 @@ def _check_tasks():
     while _tasks and _tasks[0][0] <= now:
         when, func, tag, callback, params = _tasks.pop(0)  # @UnusedVariable
 
-        logging.debug('executing task "%s"' % tag or func.__name__)
+        logging.debug(f'executing task "{tag or func.__name__}"')
         _pool.apply_async(
             func, kwds=params, callback=callback if callable(callback) else None
         )
@@ -116,7 +117,7 @@ def _load():
     file_path = os.path.join(settings.CONF_PATH, _STATE_FILE_NAME)
 
     if os.path.exists(file_path):
-        logging.debug('loading tasks from "%s"...' % file_path)
+        logging.debug(f'loading tasks from "{file_path}"...')
 
         try:
             f = open(file_path, 'rb')
@@ -139,7 +140,7 @@ def _load():
 def _save():
     file_path = os.path.join(settings.CONF_PATH, _STATE_FILE_NAME)
 
-    logging.debug('saving tasks to "%s"...' % file_path)
+    logging.debug(f'saving tasks to "{file_path}"...')
 
     try:
         f = open(file_path, 'wb')

--- a/motioneye/template.py
+++ b/motioneye/template.py
@@ -14,9 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gettext
-
-from babel.support import Translations
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from motioneye import settings

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -562,7 +562,6 @@ class GooglePhoto(UploadService, GoogleBase):
         return self._test_access()
 
     def upload_data(self, filename, mime_type, data, ctime, camera_name):
-        path = os.path.dirname(filename)
         filename = os.path.basename(filename)
         dayinfo = datetime.datetime.fromtimestamp(ctime).strftime('%Y-%m-%d')
         uploadname = dayinfo + '-' + filename
@@ -1048,12 +1047,12 @@ class FTP(UploadService):
         path = path.split('/')
         path = [p for p in path if p]
 
-        self.debug('ensuring path /%s' % '/'.join(path))
+        self.debug(f'ensuring path /{"/".join(path)}')
 
         conn.cwd('/')
         for p in path:
-            l = conn.nlst()
-            if p not in l:
+            ls = conn.nlst()
+            if p not in ls:
                 conn.mkd(p)
 
             conn.cwd(p)

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -19,16 +19,15 @@ import base64
 import hashlib
 import logging
 import os
-import re
 import subprocess
 import sys
 import time
-import typing
 import urllib.error
 import urllib.parse
 import urllib.request
 from collections import namedtuple
 from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 from PIL import Image, ImageDraw
 from tornado.concurrent import Future
@@ -74,30 +73,30 @@ GetMotionDetectionResult = namedtuple('GetMotionDetectionResult', ('enabled', 'e
 @dataclass
 class GetCurrentPictureResponse:
     motion_detected: bool = False
-    capture_fps: typing.Any = None
-    monitor_info: typing.Any = None
-    picture: typing.Any = None
-    error: typing.Any = None
+    capture_fps: Any = None
+    monitor_info: Any = None
+    picture: Any = None
+    error: Any = None
 
 
 @dataclass
 class ListMediaResponse:
-    media_list: list | None = None
-    error: str | None = None
+    media_list: Optional[list] = None
+    error: Optional[str] = None
 
 
 @dataclass
 class CommonExternalResponse:
-    result: typing.Any = None
-    error: typing.Any = None
+    result: Any = None
+    error: Any = None
 
 
-def cast_future(obj: typing.Awaitable[typing.Any]) -> Future:
-    return typing.cast(Future, obj)
+def cast_future(obj: Awaitable[Any]) -> Future:
+    return cast(Future, obj)
 
 
 def spawn_callback_timeout_wrapper(
-    callback: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    callback: Callable, *args: Any, **kwargs: Any
 ) -> None:
     IOLoop.current().spawn_callback(callback, *args, **kwargs)
 
@@ -230,8 +229,8 @@ def is_simple_mjpeg_camera(config):
     return bool(config.get('@proto') == 'mjpeg')
 
 
-def parse_cookies(cookies_headers: list[str]) -> dict[str, str]:
-    parsed: dict[str, str] = {}
+def parse_cookies(cookies_headers: List[str]) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
 
     for cookie in cookies_headers:
         for name, value in parse_cookie(cookie).items():
@@ -266,7 +265,7 @@ def build_digest_header(method, url, username, password, state):
         def md5_utf8(x):
             if isinstance(x, str):
                 x = x.encode('utf-8')
-            return hashlib.md5(x).hexdigest()
+            return hashlib.md5(x).hexdigest()  # nosec B324
 
         hash_utf8 = md5_utf8
 
@@ -275,11 +274,12 @@ def build_digest_header(method, url, username, password, state):
         def sha_utf8(x):
             if isinstance(x, str):
                 x = x.encode('utf-8')
-            return hashlib.sha1(x).hexdigest()
+            return hashlib.sha1(x).hexdigest()  # nosec B324
 
         hash_utf8 = sha_utf8
 
-    KD = lambda s, d: hash_utf8(f"{s}:{d}")
+    def KD(s, d):
+        return hash_utf8(f"{s}:{d}")
 
     if hash_utf8 is None:
         return None
@@ -308,7 +308,7 @@ def build_digest_header(method, url, username, password, state):
     s += time.ctime().encode('utf-8')
     s += os.urandom(8)
 
-    cnonce = hashlib.sha1(s).hexdigest()[:16]
+    cnonce = hashlib.sha1(s).hexdigest()[:16]  # nosec B324
     if _algorithm == 'MD5-SESS':
         HA1 = hash_utf8(f'{HA1}:{nonce}:{cnonce}')
 
@@ -324,7 +324,7 @@ def build_digest_header(method, url, username, password, state):
 
     last_nonce = nonce
 
-    base = 'username="%s", realm="%s", nonce="%s", uri="%s", ' 'response="%s"' % (
+    base = 'username="{}", realm="{}", nonce="{}", uri="{}", response="{}"'.format(
         username,
         realm,
         nonce,
@@ -404,10 +404,14 @@ def build_editable_mask_file(
     # scale the mask vertically in case the aspect ratio has changed
     # since the last time the mask has been generated
     if ny == len(mask_lines):
-        line_index_func = lambda y: y
+
+        def line_index_func(y):
+            return y
 
     else:
-        line_index_func = lambda y: (len(mask_lines) - 1) * y / ny
+
+        def line_index_func(y):
+            return (len(mask_lines) - 1) * y / ny
 
     rh = height / ny  # rectangle height
 
@@ -614,10 +618,12 @@ def call_subprocess(
 
 
 def validate_paths(
-    *paths: str | None, camera_id: str | None = None, target_dir: str | None = None
+    *paths: Optional[str],
+    camera_id: Optional[str] = None,
+    target_dir: Optional[str] = None,
 ) -> None:
     # Obtain camera dir from optional named arguments
-    camera_dir: str | None = None
+    camera_dir: Optional[str] = None
     if target_dir is not None:
         camera_dir = os.path.realpath(target_dir) + os.sep
 

--- a/motioneye/utils/authstate.py
+++ b/motioneye/utils/authstate.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from secrets import token_hex
 from time import time
+from typing import Optional
 
 # Replay cache: stores (nonce, timestamp) pairs to prevent replay attacks
 # Format: nonce -> timestamp
@@ -51,7 +52,7 @@ class PasswordHashState:
     normal: UserHashState
 
 
-_password_hash_state: PasswordHashState | None = None
+_password_hash_state: Optional[PasswordHashState] = None
 
 
 def set_password_hash_state(state: PasswordHashState) -> None:
@@ -65,7 +66,7 @@ def get_password_hash_state() -> PasswordHashState:
     return _password_hash_state
 
 
-def _build_user_hash_state(hash: str | None) -> UserHashState:
+def _build_user_hash_state(hash: Optional[str]) -> UserHashState:
     hash_type: str = 'legacy'
     if not hash:
         hash_type = 'missing'

--- a/motioneye/utils/http.py
+++ b/motioneye/utils/http.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from typing import Any, Hashable, Union
+from typing import Any, Union
 
 __all__ = ('RtmpUrl', 'RtspUrl', 'MjpegUrl')
 

--- a/motioneye/utils/rtmp.py
+++ b/motioneye/utils/rtmp.py
@@ -16,14 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from motioneye.utils import GetCamerasResponse
-from motioneye.utils.http import RtmpUrl
 
 __all__ = ('test_rtmp_url',)
 
 
 def test_rtmp_url(data: dict) -> GetCamerasResponse:
-    url_obj = RtmpUrl.from_dict(data)
-
     # Since RTMP is a binary TCP stream its a little more work to do a proper test
     # For now lets just check if a TCP socket is open on the target IP:PORT
     # TODO: Actually do the TCP SYN/ACK check...

--- a/motioneye/utils/rtsp.py
+++ b/motioneye/utils/rtsp.py
@@ -20,6 +20,7 @@ import functools
 import logging
 import re
 import socket
+from typing import List, Optional
 
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
@@ -38,8 +39,8 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
 
     called = [False]
     send_auth = [False]
-    timeout: list[object | None] = [None]
-    stream: IOStream | None = None
+    timeout: List[Optional[object]] = [None]
+    stream: Optional[IOStream] = None
 
     io_loop = IOLoop.current()
     future: Future = Future()
@@ -47,12 +48,10 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
     def connect() -> None:
         nonlocal stream
         if send_auth[0]:
-            logging.debug(
-                'testing rtsp netcam at %s (this time with credentials)' % url
-            )
+            logging.debug(f'testing rtsp netcam at {url} (this time with credentials)')
 
         else:
-            logging.debug('testing rtsp netcam at %s' % url)
+            logging.debug(f'testing rtsp netcam at {url}')
 
         if stream is not None:
             try:
@@ -87,7 +86,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
         else:
             logging.debug('connected to rtsp netcam')
 
-            lines = ['OPTIONS %s RTSP/1.0' % url, 'CSeq: 1', 'User-Agent: motionEye']
+            lines = [f'OPTIONS {url} RTSP/1.0', 'CSeq: 1', 'User-Agent: motionEye']
 
             if url_obj.username and send_auth[0]:
                 auth_header = 'Authorization: ' + build_basic_header(
@@ -111,7 +110,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
             if stream is None:
                 return handle_error('connection closed')
 
-            r_future = cast_future(stream.read_until_regex(br'RTSP/1.0 \d+ '))
+            r_future = cast_future(stream.read_until_regex(rb'RTSP/1.0 \d+ '))
             r_future.add_done_callback(on_rtsp)
             timeout[0] = io_loop.add_timeout(
                 datetime.timedelta(seconds=settings.MJPG_CLIENT_TIMEOUT),
@@ -141,7 +140,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
                     seek_www_authenticate()
 
             else:
-                handle_error('rtsp netcam returned erroneous response: %s' % data)
+                handle_error(f'rtsp netcam returned erroneous response: {data}')
 
     def seek_server():
         if check_error():
@@ -160,7 +159,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
         io_loop.remove_timeout(timeout[0])
         if data:
             identifier = re.findall('Server: (.*)', data.decode())[0].strip()
-            logging.debug('rtsp netcam identifier is "%s"' % identifier)
+            logging.debug(f'rtsp netcam identifier is "{identifier}"')
 
         else:
             identifier = None
@@ -190,8 +189,8 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
             handle_error(f'{auth_timeout_msg}')
         else:
             if data:
-                scheme = re.findall(br'WWW-Authenticate: ([^\s]+)', data)[0].strip()
-                logging.debug('rtsp netcam auth scheme: %s' % scheme)
+                scheme = re.findall(rb'WWW-Authenticate: ([^\s]+)', data)[0].strip()
+                logging.debug(f'rtsp netcam auth scheme: {scheme}')
                 if scheme.lower() == 'basic':
                     send_auth[0] = True
                     connect()
@@ -225,8 +224,8 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
         else:
             identifier = ''
 
-        cameras.append({'id': 'tcp', 'name': '%sRTSP/TCP Camera' % identifier})
-        cameras.append({'id': 'udp', 'name': '%sRTSP/UDP Camera' % identifier})
+        cameras.append({'id': 'tcp', 'name': f'{identifier}RTSP/TCP Camera'})
+        cameras.append({'id': 'udp', 'name': f'{identifier}RTSP/UDP Camera'})
 
         future.set_result(GetCamerasResponse(cameras, None))
 
@@ -235,7 +234,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
             return
 
         called[0] = True
-        logging.error('rtsp client error: %s' % str(e))
+        logging.error(f'rtsp client error: {e}')
 
         try:
             stream.close()
@@ -243,7 +242,7 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
         except Exception:
             pass
 
-        future.set_result(GetCamerasResponse(None, error=str(e)))
+        future.set_result(GetCamerasResponse(None, error=e))
 
     def check_error():
         error = getattr(stream, 'error', None)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest import mock
 
 from tornado.testing import AsyncHTTPTestCase
@@ -20,7 +21,7 @@ class AsyncMock(mock.MagicMock):
 
 
 class WebTestCase(AsyncHTTPTestCase):
-    handler: type | None = None
+    handler: Optional[type] = None
 
     def get_app(self):
         self.app = Application(self.get_handlers(), **self.get_app_kwargs())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ import unittest
 from io import BytesIO
 from shutil import rmtree
 from tempfile import mkdtemp
+from typing import Optional
 
 from motioneye import config, settings
 
@@ -49,7 +50,9 @@ class TestBackup(unittest.TestCase):
         for name in names:
             open(os.path.join(self.conf_dir, name), 'a').close()
 
-    def _assert_tarball_members(self, data: bytes | None, expected: list[str]) -> None:
+    def _assert_tarball_members(
+        self, data: Optional[bytes], expected: list[str]
+    ) -> None:
         if data is None:
             self.fail('tarball data is None')
 

--- a/tests/test_handlers/__init__.py
+++ b/tests/test_handlers/__init__.py
@@ -4,7 +4,7 @@ from secrets import token_hex
 from shutil import rmtree
 from tempfile import mkdtemp
 from time import time
-from typing import Generic, Type, TypeVar
+from typing import Generic, Optional, Type, TypeVar
 from unittest.mock import MagicMock, patch
 
 from tornado.testing import AsyncHTTPTestCase
@@ -73,7 +73,7 @@ class HandlerTestCase(AsyncHTTPTestCase, Generic[T]):
         # Wipe any sessions left over from this test so the next test starts clean.
         _session_store.clear()
 
-    def get_handler(self, request: MagicMock | None = None) -> T:
+    def get_handler(self, request: Optional[MagicMock] = None) -> T:
         req = request or MagicMock()
         return self.handler_cls(self.app, req)
 

--- a/tests/test_handlers/test_login.py
+++ b/tests/test_handlers/test_login.py
@@ -83,7 +83,7 @@ class LoginHandlerTest(HandlerTestCase):
     def test_login_legacy_password_migrates(self):
         admin_user = 'admin'
         plain = 's3cret'
-        legacy_hash = sha1(plain.encode()).hexdigest()
+        legacy_hash = sha1(plain.encode()).hexdigest()  # nosec B324
         main_config = {
             '@admin_username': admin_user,
             '@admin_password': legacy_hash,


### PR DESCRIPTION
by using Python 3.7 compatible typing. Also use f-strings where possible in touched files.

Add Python 3.7 to our test matrix, as pre-commit default version, and add ruff linter and formatter with Python 3.7 as target version.

Also add Ubuntu 26.04 Resolute runners to test matrix for Python 3.14 tests, which are in preview state.