### PR TITLE
enh(config): use "pause" setting from motion 4.4 on

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -16,7 +16,6 @@
 
 import logging
 import os.path
-import subprocess
 import tarfile
 from collections import OrderedDict
 from datetime import timedelta
@@ -29,6 +28,7 @@ from re import match, sub
 from secrets import token_hex
 from shlex import split
 from stat import S_IMODE
+from subprocess import STDOUT
 from typing import Optional
 from urllib.parse import quote, urlunparse
 
@@ -864,9 +864,7 @@ def main_ui_to_dict(ui):
             env = {'MEYE_USERNAME': u, 'MEYE_PASSWORD': p}
 
             try:
-                utils.call_subprocess(
-                    settings.PASSWORD_HOOK, env=env, stderr=subprocess.STDOUT
-                )
+                utils.call_subprocess(settings.PASSWORD_HOOK, env=env, stderr=STDOUT)
                 logging.debug('password hook exec succeeded')
 
             except Exception as e:

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -632,6 +632,8 @@ def set_camera(camera_id, camera_config):
 
         elif motionctl.is_motion_post43():
             adapt_config_directives(camera_config, _MOTION_43_TO_44_OPTIONS_MAPPING)
+            # use new "pause" setting to enable/disable motion detection
+            camera_config['pause'] = not camera_config['@motion_detection']
 
         # set the enabled status in main config
         main_config = get_main()

--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -134,7 +134,9 @@ def start(deferred=False):
     with open(motion_pid_path, 'w') as f:
         f.write(str(pid) + '\n')
 
-    IOLoop.current().spawn_callback(_disable_initial_motion_detection)
+    # disable motion detection if version < 4.4, otherwise the new "pause" setting does
+    if not is_motion_post43():
+        IOLoop.current().spawn_callback(_disable_initial_motion_detection)
 
     # if mjpg client idle timeout is disabled, create mjpg clients for all cameras by default
     if not settings.MJPG_CLIENT_IDLE_TIMEOUT:
@@ -372,8 +374,6 @@ def has_h264_omx_support():
     if not binary:
         return False
 
-    # TODO also check for motion codec parameter support
-
     return 'h264_omx' in codecs.get('h264', {}).get('encoders', set())
 
 
@@ -381,8 +381,6 @@ def has_h264_v4l2m2m_support():
     binary, version, codecs = mediafiles.find_ffmpeg()
     if not binary:
         return False
-
-    # TODO also check for motion codec parameter support
 
     return 'h264_v4l2m2m' in codecs.get('h264', {}).get('encoders', set())
 
@@ -436,7 +434,7 @@ def has_hevc_qsv_support():
 
 
 def resolution_is_valid(width, height):
-    # width & height must be be modulo 8
+    # width & height must be modulo 8
 
     if width % 8:
         return False

--- a/motioneye/motionctl.py
+++ b/motioneye/motionctl.py
@@ -14,14 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import errno
 import logging
-import os.path
 import re
-import signal
-import subprocess
-import time
+from errno import ECHILD, ESRCH
+from os import WNOHANG, kill, waitpid
+from os.path import exists, join
 from shlex import quote
+from signal import SIGKILL, SIGTERM
+from subprocess import CalledProcessError, Popen
+from time import sleep
 
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.ioloop import IOLoop
@@ -43,7 +44,7 @@ def find_motion():
 
     # binary
     if settings.MOTION_BINARY:
-        if os.path.exists(settings.MOTION_BINARY):
+        if exists(settings.MOTION_BINARY):
             binary = settings.MOTION_BINARY
 
         else:
@@ -53,14 +54,14 @@ def find_motion():
         try:
             binary = utils.call_subprocess(['which', 'motion'])
 
-        except subprocess.CalledProcessError:  # not found
+        except CalledProcessError:  # not found
             return None, None
 
     # version
     try:
         output = utils.call_subprocess(quote(binary) + ' -h || true', shell=True)
 
-    except subprocess.CalledProcessError as e:  # not found as
+    except CalledProcessError as e:  # not found as
         logging.error(f'motion version could not be found: {e}')
         return None, None
 
@@ -97,9 +98,9 @@ def start(deferred=False):
 
     logging.debug(f'starting motion executable "{binary}" version "{version}"')
 
-    motion_cfg_path = os.path.join(settings.CONF_PATH, 'motion.conf')
-    motion_log_path = os.path.join(settings.LOG_PATH, 'motion.log')
-    motion_pid_path = os.path.join(settings.RUN_PATH, 'motion.pid')
+    motion_cfg_path = join(settings.CONF_PATH, 'motion.conf')
+    motion_log_path = join(settings.LOG_PATH, 'motion.log')
+    motion_pid_path = join(settings.RUN_PATH, 'motion.pid')
 
     args = [binary, '-n', '-c', motion_cfg_path, '-d']
 
@@ -117,13 +118,13 @@ def start(deferred=False):
 
     log_file = open(motion_log_path, 'w')
 
-    process = subprocess.Popen(
+    process = Popen(
         args, stdout=log_file, stderr=log_file, close_fds=True, cwd=settings.CONF_PATH
     )
 
     # wait 2 seconds to see that the process has successfully started
     for _ in range(20):
-        time.sleep(0.1)
+        sleep(0.1)
         exit_code = process.poll()
         if exit_code is not None and exit_code != 0:
             raise Exception(f'motion failed to start with exit code "{exit_code}"')
@@ -163,20 +164,20 @@ def stop(invalidate=False):
     if pid is not None:
         try:
             # send the TERM signal once
-            os.kill(pid, signal.SIGTERM)
+            kill(pid, SIGTERM)
 
             # wait 5 seconds for the process to exit
-            for i in range(50):  # @UnusedVariable
-                os.waitpid(pid, os.WNOHANG)
-                time.sleep(0.1)
+            for _ in range(50):
+                waitpid(pid, WNOHANG)
+                sleep(0.1)
 
             # send the KILL signal once
-            os.kill(pid, signal.SIGKILL)
+            kill(pid, SIGKILL)
 
             # wait 2 seconds for the process to exit
-            for i in range(20):  # @UnusedVariable
-                time.sleep(0.1)
-                os.waitpid(pid, os.WNOHANG)
+            for _ in range(20):
+                sleep(0.1)
+                waitpid(pid, WNOHANG)
 
             # the process still did not exit
             if settings.ENABLE_REBOOT:
@@ -187,7 +188,7 @@ def stop(invalidate=False):
                 raise Exception('could not terminate the motion process')
 
         except OSError as e:
-            if e.errno not in (errno.ESRCH, errno.ECHILD):
+            if e.errno not in (ESRCH, ECHILD):
                 raise
 
 
@@ -197,14 +198,14 @@ def running():
         return False
 
     try:
-        os.waitpid(pid, os.WNOHANG)
-        os.kill(pid, 0)
+        waitpid(pid, WNOHANG)
+        kill(pid, 0)
 
         # the process is running
         return True
 
     except OSError as e:
-        if e.errno not in (errno.ESRCH, errno.ECHILD):
+        if e.errno not in (ESRCH, ECHILD):
             raise
 
     return False
@@ -461,7 +462,7 @@ async def _disable_initial_motion_detection():
 
 
 def _get_pid():
-    motion_pid_path = os.path.join(settings.RUN_PATH, 'motion.pid')
+    motion_pid_path = join(settings.RUN_PATH, 'motion.pid')
 
     # read the pid from file
     try:


### PR DESCRIPTION
This allows starting motion with motion detection disabled, rendering the API request at startup obsolete. That request could have been done too early if motion took more than 2 seconds to start.