### PR TITLE
fix(smbctl): probe CIFS sec modes strongest-first to avoid 'ntlm' kernel warning

### DIFF
--- a/motioneye/controls/smbctl.py
+++ b/motioneye/controls/smbctl.py
@@ -217,11 +217,21 @@ def _mount(server, share, smb_ver, username, password):
     if username:
         opts = f'username={username},password={password}'
         # Let the kernel negotiate its default first (None), then try the
-        # security modes from strongest to weakest. The legacy NTLMv1 'ntlm'
-        # mode is kept last as a fallback for very old servers: since a working
-        # modern mode is found first, recent kernels (which removed 'ntlm') no
-        # longer reach it and stop logging "bad security option: ntlm" (#3013).
-        sec_types = [None, 'ntlmsspi', 'ntlmssp', 'ntlmv2i', 'ntlmv2', 'ntlm', 'none']
+        # security modes from strongest to weakest, each signed ('*i') variant
+        # before its unsigned counterpart. The legacy NTLMv1 'ntlm' mode is
+        # kept last as a fallback for very old servers: since a working modern
+        # mode is found first, recent kernels (which removed 'ntlm') no longer
+        # reach it and stop logging "bad security option: ntlm" (#3013).
+        sec_types = [
+            None,
+            'ntlmsspi',
+            'ntlmssp',
+            'ntlmv2i',
+            'ntlmv2',
+            'ntlmi',
+            'ntlm',
+            'none',
+        ]
 
     else:
         opts = 'guest'

--- a/motioneye/controls/smbctl.py
+++ b/motioneye/controls/smbctl.py
@@ -216,11 +216,18 @@ def _mount(server, share, smb_ver, username, password):
 
     if username:
         opts = f'username={username},password={password}'
-        sec_types = [None, 'ntlm', 'ntlmv2', 'ntlmv2i', 'ntlmsspi', 'none']
+        # Let the kernel negotiate its default first (None), then try the
+        # security modes from strongest to weakest. The legacy NTLMv1 'ntlm'
+        # mode is kept last as a fallback for very old servers: since a working
+        # modern mode is found first, recent kernels (which removed 'ntlm') no
+        # longer reach it and stop logging "bad security option: ntlm" (#3013).
+        sec_types = [None, 'ntlmsspi', 'ntlmssp', 'ntlmv2i', 'ntlmv2', 'ntlm', 'none']
 
     else:
         opts = 'guest'
-        sec_types = [None, 'none', 'ntlm', 'ntlmv2', 'ntlmv2i', 'ntlmsspi']
+        # Without credentials only a null-user session is meaningful; the
+        # password-hashing modes do not apply.
+        sec_types = [None, 'none']
 
     opts += ',vers=%s' % smb_ver
 


### PR DESCRIPTION
## What

Reorder the CIFS `sec=` modes that `smbctl._mount()` probes so the strongest modes are tried first, eliminating the `kernel: bad security option: ntlm` warning reported in #3013.

## Why

Recent Linux kernels (>= 5.15.61) removed the insecure `ntlm` (NTLMv1) CIFS security mode. With the old probe order:

```python
sec_types = [None, 'ntlm', 'ntlmv2', 'ntlmv2i', 'ntlmsspi', 'none']
```

`ntlm` was attempted very early, so `mount.cifs` logged `bad security option: ntlm` on every mount even though the share ultimately mounted via a later mode. The warning is harmless but noisy and confusing.

## How

- Probe order is now `None` (kernel default) first, then strongest → weakest, with legacy `ntlm` kept last as a fallback for very old servers:

  ```python
  sec_types = [None, 'ntlmsspi', 'ntlmssp', 'ntlmv2i', 'ntlmv2', 'ntlm', 'none']
  ```

  Because a working modern mode is found before `ntlm` is reached, recent kernels never attempt it and stop logging the warning.
- Added the `ntlmssp` mode (the kernel default since Linux 3.8) which was missing from the list.
- Simplified the guest (no-credentials) path to `[None, 'none']`, since the password-hashing modes are meaningless without a username.

This follows the approach @MichaIng suggested in the issue discussion (try most-secure first; `none` only for the credential-less case).

## Scope

This only addresses the `ntlm` warning. The separate `mount error(16): Device or resource busy` / re-mount behaviour also noted in #3013 is left for a follow-up, as suggested in the thread.

## Testing

- `ruff check` and `ruff format --check` pass on the changed file.
- Change is limited to the static `sec_types` probe lists; the mount/retry loop is unchanged.

Closes #3013
