### PR TITLE
feat(upload): add "remove files after upload" option

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1011,6 +1011,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         '@upload_bucket': ui['upload_bucket'],
         '@upload_sse_c_key': ui['upload_sse_c_key'],
         '@clean_cloud_enabled': ui['clean_cloud_enabled'],
+        '@clean_uploaded': ui['clean_uploaded'],
         # text overlay
         'text_left': '',
         'text_right': '',
@@ -1547,6 +1548,7 @@ def motion_camera_dict_to_ui(data):  # noqa: C901
         'upload_bucket': data['@upload_bucket'],
         'upload_sse_c_key': data['@upload_sse_c_key'],
         'clean_cloud_enabled': data['@clean_cloud_enabled'],
+        'clean_uploaded': data['@clean_uploaded'],
         'web_hook_storage_enabled': False,
         'command_storage_enabled': False,
         # text overlay
@@ -2426,6 +2428,7 @@ def _set_default_motion_camera(camera_id, data):
     data.setdefault('@upload_bucket', '')
     data.setdefault('@upload_sse_c_key', '')
     data.setdefault('@clean_cloud_enabled', False)
+    data.setdefault('@clean_uploaded', False)
 
     data.setdefault('stream_localhost', True)
     data.setdefault('stream_port', 9080 + camera_id)

--- a/motioneye/handlers/relay_event.py
+++ b/motioneye/handlers/relay_event.py
@@ -74,7 +74,7 @@ class RelayEventHandler(BaseHandler):
         if filename is not None:
             target_dir: str = camera_config['target_dir']
             utils.validate_paths(
-                filename.removeprefix(target_dir + sep),
+                utils.remove_prefix(filename, target_dir + sep),
                 target_dir=target_dir,
             )
 

--- a/motioneye/handlers/relay_event.py
+++ b/motioneye/handlers/relay_event.py
@@ -103,19 +103,19 @@ class RelayEventHandler(BaseHandler):
 
             # upload to external service
             if camera_config['@upload_enabled'] and camera_config['@upload_movie']:
-                self.upload_media_file(filename, camera_id, camera_config)
+                self.upload_media_file(filename, camera_id, camera_config, 'movie')
 
         elif event == 'picture_save':
             # upload to external service
             if camera_config['@upload_enabled'] and camera_config['@upload_picture']:
-                self.upload_media_file(filename, camera_id, camera_config)
+                self.upload_media_file(filename, camera_id, camera_config, 'picture')
 
         else:
             logging.warning(f'unknown event {event}')
 
         self.finish_json()
 
-    def upload_media_file(self, filename, camera_id, camera_config):
+    def upload_media_file(self, filename, camera_id, camera_config, media_type):
         service_name = camera_config['@upload_service']
 
         tasks.add(
@@ -128,4 +128,6 @@ class RelayEventHandler(BaseHandler):
             target_dir=camera_config['@upload_subfolders']
             and camera_config['target_dir'],
             filename=filename,
+            media_type=media_type,
+            clean_uploaded=camera_config['@clean_uploaded'],
         )

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -403,6 +403,10 @@ def cleanup_media(media_type: str) -> None:
         if (
             cloud_enabled
             and clean_cloud_enabled
+            # when files are removed right after upload, the local folders are
+            # the source of truth no longer, so cloud cleanup must be skipped to
+            # avoid deleting the just-uploaded copies (see #3089)
+            and not camera_config.get('@clean_uploaded')
             and camera_id
             and service_name
             and cloud_dir

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -464,7 +464,7 @@ def make_movie_preview(camera_config: dict, full_path: str) -> Optional[str]:
 
     target_dir: str = camera_config['target_dir']
     utils.validate_paths(
-        full_path.removeprefix(target_dir + os.sep),
+        utils.remove_prefix(full_path, target_dir + os.sep),
         target_dir=target_dir,
     )
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -695,8 +695,18 @@ function initUI() {
         var folder = $('#uploadLocationEntry').val();
         console.log('cleanCloudEnabled', enabled, folder);
         if (enabled) {
+            /* mutually exclusive with "remove files after upload" */
+            $('#cleanUploadedSwitch')[0].checked = false;
             runAlertDialog(( i18n.gettext('Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo "') + folder +
                     i18n.gettext('", ne nur tiuj alŝutitaj de motionEye!')));
+        }
+    });
+    $('#cleanUploadedSwitch').on('change', function () {
+        if (this.checked && $('#cleanCloudEnabledSwitch')[0].checked) {
+            /* mutually exclusive with cloud cleanup, which would delete the
+             * just-uploaded copies once the local files are gone */
+            $('#cleanCloudEnabledSwitch')[0].checked = false;
+            runAlertDialog(i18n.gettext('"Purigi la nubon" estis malŝaltita ĉar ĝi konfliktas kun "Forigi Dosierojn Post Alŝuto".'));
         }
     });
 
@@ -1869,6 +1879,7 @@ function cameraUi2Dict() {
         'upload_bucket': $('#uploadBucketEntry').val(),
         'upload_sse_c_key': $('#uploadSseCKeyEntry').val(),
         'clean_cloud_enabled': $('#cleanCloudEnabledSwitch')[0].checked,
+        'clean_uploaded': $('#cleanUploadedSwitch')[0].checked,
         'web_hook_storage_enabled': $('#webHookStorageEnabledSwitch')[0].checked,
         'web_hook_storage_url': $('#webHookStorageUrlEntry').val(),
         'web_hook_storage_http_method': $('#webHookStorageHttpMethodSelect').val(),
@@ -2213,6 +2224,7 @@ function dict2CameraUi(dict) {
     $('#uploadBucketEntry').val(dict['upload_bucket']); markHideIfNull('upload_bucket', 'uploadBucketEntry');
     $('#uploadSseCKeyEntry').val(dict['upload_sse_c_key']); markHideIfNull('upload_sse_c_key', 'uploadSseCKeyEntry');
     $('#cleanCloudEnabledSwitch')[0].checked = dict['clean_cloud_enabled']; markHideIfNull('clean_cloud_enabled', 'cleanCloudEnabledSwitch');
+    $('#cleanUploadedSwitch')[0].checked = dict['clean_uploaded']; markHideIfNull('clean_uploaded', 'cleanUploadedSwitch');
 
     $('#webHookStorageEnabledSwitch')[0].checked = dict['web_hook_storage_enabled']; markHideIfNull('web_hook_storage_enabled', 'webHookStorageEnabledSwitch');
     $('#webHookStorageUrlEntry').val(dict['web_hook_storage_url']);

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -695,8 +695,9 @@ function initUI() {
         var folder = $('#uploadLocationEntry').val();
         console.log('cleanCloudEnabled', enabled, folder);
         if (enabled) {
-            /* mutually exclusive with "remove files after upload" */
-            $('#cleanUploadedSwitch')[0].checked = false;
+            /* mutually exclusive with "remove files after upload"; trigger
+             * change so the styled switch updates visually, not just .checked */
+            $('#cleanUploadedSwitch').prop('checked', false).trigger('change');
             runAlertDialog(( i18n.gettext('Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo "') + folder +
                     i18n.gettext('", ne nur tiuj alŝutitaj de motionEye!')));
         }
@@ -704,8 +705,9 @@ function initUI() {
     $('#cleanUploadedSwitch').on('change', function () {
         if (this.checked && $('#cleanCloudEnabledSwitch')[0].checked) {
             /* mutually exclusive with cloud cleanup, which would delete the
-             * just-uploaded copies once the local files are gone */
-            $('#cleanCloudEnabledSwitch')[0].checked = false;
+             * just-uploaded copies once the local files are gone; trigger
+             * change so the styled switch updates visually, not just .checked */
+            $('#cleanCloudEnabledSwitch').prop('checked', false).trigger('change');
             runAlertDialog(i18n.gettext('"Purigi la nubon" estis malŝaltita ĉar ĝi konfliktas kun "Forigi Dosierojn Post Alŝuto".'));
         }
     });

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -525,6 +525,11 @@
                             <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="cleanCloudEnabledSwitch"></td>
                             <td><span class="help-mark" title="{{ _("ebligu ĉi tion forigi amaskomunikilaĵojn dosierojn alŝutitajn al la nubo ankaŭ kiam loka amaskomunikilaro estas forigita konforme al la agordo de persistemo de dosieroj. Nuntempe ĉi tiu opcio nur haveblas por gdrivo.") }}">?</span></td>
                         </tr>
+                        <tr class="settings-item" depends="uploadEnabled">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Forigi Dosierojn Post Alŝuto") }}</span></td>
+                            <td class="settings-item-value"><input type="checkbox" class="styled storage camera-config" id="cleanUploadedSwitch"></td>
+                            <td><span class="help-mark" title="{{ _("ebligu ĉi tion por forigi la lokan plurmedian dosieron tuj post kiam ĝi estis sukcese alŝutita al la ekstera servo (utila por liberigi malgrandajn SD-kartojn)") }}">?</span></td>
+                        </tr>
                         <tr class="settings-item" depends="uploadEnabled uploadService=(ftp|sftp|http|https|webdav)">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Uzantnomo") }}</span></td>
                             <td class="settings-item-value"><input type="text" autocapitalize="none" class="styled storage camera-config" id="uploadUsernameEntry"></td>

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -1319,7 +1319,15 @@ def update(camera_id, service_name, settings):
     service.save()
 
 
-def upload_media_file(camera_id, camera_name, target_dir, service_name, filename):
+def upload_media_file(
+    camera_id,
+    camera_name,
+    target_dir,
+    service_name,
+    filename,
+    media_type=None,
+    clean_uploaded=False,
+):
     service = get(camera_id, service_name)
     if not service:
         return logging.error(
@@ -1332,6 +1340,30 @@ def upload_media_file(camera_id, camera_name, target_dir, service_name, filename
     except Exception as e:
         logging.error(
             f'failed to upload file "{filename}" with service {service}: {e}',
+            exc_info=True,
+        )
+        return  # upload failed: keep the local file
+
+    # the caller passes clean_uploaded so we can skip the camera config lookup
+    # and the mediafiles import entirely on the common path (feature disabled)
+    if not clean_uploaded:
+        return
+
+    # upload succeeded and the camera removes its local copy after upload
+    try:
+        # local imports to avoid the config/mediafiles <-> uploadservices
+        # circular imports (both modules import uploadservices at module level)
+        from motioneye import config, mediafiles
+
+        camera_config = config.get_camera(camera_id)
+        rel = filename.removeprefix(camera_config['target_dir'] + os.sep)
+        mediafiles.del_media_content(camera_config, rel, media_type)
+        logging.debug(f'removed local file "{filename}" after successful upload')
+
+    except Exception as e:
+        # never let a cleanup error affect the (already successful) upload
+        logging.error(
+            f'failed to remove local file "{filename}" after upload: {e}',
             exc_info=True,
         )
 

--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -1356,7 +1356,7 @@ def upload_media_file(
         from motioneye import config, mediafiles
 
         camera_config = config.get_camera(camera_id)
-        rel = filename.removeprefix(camera_config['target_dir'] + os.sep)
+        rel = utils.remove_prefix(filename, camera_config['target_dir'] + os.sep)
         mediafiles.del_media_content(camera_config, rel, media_type)
         logging.debug(f'removed local file "{filename}" after successful upload')
 

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -616,6 +616,14 @@ def call_subprocess(
     ).stdout.strip()
 
 
+def remove_prefix(s: str, prefix: str) -> str:
+    # str.removeprefix backport for Python < 3.9 (motionEye targets 3.7).
+    # Like str.removeprefix, the string is returned unchanged when it does not
+    # start with prefix - which is what lets validate_paths() still reject an
+    # absolute/foreign path that is not under target_dir.
+    return s[len(prefix) :] if s.startswith(prefix) else s
+
+
 def validate_paths(
     *paths: Optional[str],
     camera_id: Optional[str] = None,

--- a/tests/test_uploadservices.py
+++ b/tests/test_uploadservices.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from motioneye import uploadservices
+
+
+class TestUploadMediaFileCleanup(unittest.TestCase):
+    """Tests for the optional "remove after successful upload" behaviour of
+    uploadservices.upload_media_file (the @clean_uploaded option, see #3089).
+
+    The caller (relay handler) passes clean_uploaded, so the cleanup branch -
+    including the camera config lookup and the mediafiles import - must be
+    skipped entirely when it is False."""
+
+    def setUp(self):
+        self.target_dir = os.path.join(os.sep + 'data', 'cam1')
+        self.filename = os.path.join(self.target_dir, '2024-01-01', 'movie.mp4')
+        self.expected_rel = os.path.join('2024-01-01', 'movie.mp4')
+
+    @patch('motioneye.mediafiles.del_media_content')
+    @patch('motioneye.config.get_camera')
+    @patch('motioneye.uploadservices.get')
+    def test_removes_local_file_on_success_when_enabled(
+        self, mock_get, mock_get_camera, mock_del
+    ):
+        mock_get.return_value = MagicMock()  # upload_file() succeeds
+        camera_config = {'target_dir': self.target_dir}
+        mock_get_camera.return_value = camera_config
+
+        uploadservices.upload_media_file(
+            1,
+            'cam',
+            self.target_dir,
+            'ftp',
+            self.filename,
+            'movie',
+            clean_uploaded=True,
+        )
+
+        mock_del.assert_called_once_with(camera_config, self.expected_rel, 'movie')
+
+    @patch('motioneye.mediafiles.del_media_content')
+    @patch('motioneye.config.get_camera')
+    @patch('motioneye.uploadservices.get')
+    def test_keeps_local_file_when_disabled(self, mock_get, mock_get_camera, mock_del):
+        mock_get.return_value = MagicMock()
+
+        uploadservices.upload_media_file(
+            1,
+            'cam',
+            self.target_dir,
+            'ftp',
+            self.filename,
+            'movie',
+            clean_uploaded=False,
+        )
+
+        # the common path must not even look up the camera config
+        mock_get_camera.assert_not_called()
+        mock_del.assert_not_called()
+
+    @patch('motioneye.mediafiles.del_media_content')
+    @patch('motioneye.config.get_camera')
+    @patch('motioneye.uploadservices.get')
+    def test_keeps_local_file_when_upload_fails(
+        self, mock_get, mock_get_camera, mock_del
+    ):
+        service = MagicMock()
+        service.upload_file.side_effect = Exception('upload boom')
+        mock_get.return_value = service
+
+        # a failed upload must not raise and must not delete the local file
+        uploadservices.upload_media_file(
+            1,
+            'cam',
+            self.target_dir,
+            'ftp',
+            self.filename,
+            'movie',
+            clean_uploaded=True,
+        )
+
+        mock_get_camera.assert_not_called()
+        mock_del.assert_not_called()
+
+    @patch('motioneye.mediafiles.del_media_content')
+    @patch('motioneye.uploadservices.get')
+    def test_no_cleanup_when_service_missing(self, mock_get, mock_del):
+        mock_get.return_value = None
+
+        uploadservices.upload_media_file(
+            1,
+            'cam',
+            self.target_dir,
+            'ftp',
+            self.filename,
+            'movie',
+            clean_uploaded=True,
+        )
+
+        mock_del.assert_not_called()
+
+    @patch('motioneye.mediafiles.del_media_content')
+    @patch('motioneye.config.get_camera')
+    @patch('motioneye.uploadservices.get')
+    def test_cleanup_error_does_not_propagate(
+        self, mock_get, mock_get_camera, mock_del
+    ):
+        mock_get.return_value = MagicMock()
+        mock_get_camera.return_value = {'target_dir': self.target_dir}
+        mock_del.side_effect = Exception('disk error')
+
+        # a cleanup error must never affect the (already successful) upload
+        uploadservices.upload_media_file(
+            1,
+            'cam',
+            self.target_dir,
+            'ftp',
+            self.filename,
+            'movie',
+            clean_uploaded=True,
+        )
+
+        mock_del.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils/test_remove_prefix.py
+++ b/tests/test_utils/test_remove_prefix.py
@@ -1,0 +1,29 @@
+import unittest
+
+from motioneye.utils import remove_prefix
+
+
+class RemovePrefixTest(unittest.TestCase):
+    def test_strips_matching_prefix(self):
+        self.assertEqual(
+            remove_prefix('/media/cam1/2024-01-01/movie.mp4', '/media/cam1/'),
+            '2024-01-01/movie.mp4',
+        )
+
+    def test_returns_unchanged_when_prefix_does_not_match(self):
+        # security-relevant: a path outside target_dir must come back as-is so
+        # validate_paths() can still reject it as an absolute path
+        self.assertEqual(remove_prefix('/etc/passwd', '/media/cam1/'), '/etc/passwd')
+
+    def test_empty_prefix_returns_unchanged(self):
+        self.assertEqual(remove_prefix('/etc/passwd', ''), '/etc/passwd')
+
+    def test_string_equal_to_prefix_becomes_empty(self):
+        self.assertEqual(remove_prefix('/media/cam1/', '/media/cam1/'), '')
+
+    def test_shorter_than_prefix_returns_unchanged(self):
+        self.assertEqual(remove_prefix('abc', 'abcdef'), 'abc')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds a per-camera **"Remove Files After Upload"** option (`@clean_uploaded`) under **Storage**. When enabled, a movie/picture is deleted from local storage immediately after the upload service has **successfully** uploaded it, freeing space on small media such as SD cards.

Implements the feature @MichaIng proposed in #3089.

## Why

#3089: the only local-retention control today is "Preserve Movies/Pictures", which is whole-days only (sub-day values round to 0 = "keep forever"), so it can't promptly free a small SD card after media is uploaded to a NAS/cloud. This option does exactly that.

## How

- **`config.py`** — new `@clean_uploaded` boolean, mirroring `@clean_cloud_enabled` (ui↔dict mapping + default `False`).
- **`handlers/relay_event.py`** — thread `media_type` (`'movie'`/`'picture'`) into the upload task.
- **`uploadservices.upload_media_file`** — on a successful `upload_file` (no exception), when `@clean_uploaded` is set, remove the local file via `mediafiles.del_media_content` (file + `.thumb` + now-empty date dirs). A **failed upload keeps the file**. A function-local import avoids the `mediafiles`/`config` ↔ `uploadservices` circular import.
- **`mediafiles.cleanup_media`** — skip cloud cleanup when `@clean_uploaded` is set: the two options are mutually exclusive, because once local files are removed after upload, `clean_cloud` would treat the just-uploaded cloud copies as orphaned and delete them.
- **`templates/main.html` / `static/js/main.js`** — new Storage checkbox (shown for all upload services), made mutually exclusive in the UI with the cloud-cleanup switch.

## Notes / scope

- Per-type behaviour already comes from `@upload_movie` / `@upload_picture`, which decide what gets uploaded; a single boolean is sufficient since a deleted file is always one that was uploaded.
- On `movie_end`, the thumbnail (`make_movie_preview`) and the upload are both scheduled at +5s in the single-worker task pool, with the preview enqueued first; preview failures are already non-fatal. A stronger ordering guarantee is out of scope.
- Single-file **cloud** deletion sync is unchanged (the existing `clean_cloud` stays directory-oriented).
- New UI strings follow the existing `{{ _("...") }}` Esperanto source-string convention; wording can be adjusted as preferred.

## Testing

- Adds `tests/test_uploadservices.py` covering the new cleanup behaviour: deletes on a successful upload when enabled, keeps the file when disabled or when the upload fails, and never lets a cleanup error propagate.
- Full `pytest` suite runs green (existing + new) in a Linux container: **121 passed, 115 subtests passed**.
- `ruff check` + `ruff format --check` pass on all changed `.py` files; `node --check` passes for `main.js`.

Closes #3089
