### PR TITLE
fix(dropbox): encode test_access JSON body as bytes

### DIFF
--- a/motioneye/uploadservices.py
+++ b/motioneye/uploadservices.py
@@ -705,7 +705,9 @@ class Dropbox(UploadService):
             'include_deleted': False,
         }
 
-        body = json.dumps(body)
+        # the body must be bytes: urllib's Request rejects a str POST body
+        # with "POST data should be bytes ... not str" (#2828)
+        body = json.dumps(body).encode()
         headers = {'Content-Type': 'application/json'}
 
         try:

--- a/tests/test_uploadservices_dropbox.py
+++ b/tests/test_uploadservices_dropbox.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import unittest
+from unittest.mock import patch
+
+from motioneye.uploadservices import Dropbox
+
+
+class TestDropboxTestAccess(unittest.TestCase):
+    """Dropbox.test_access must send a bytes POST body; urllib's Request rejects
+    a str body with "POST data should be bytes ... not str" (#2828)."""
+
+    @patch.object(Dropbox, '_request')
+    def test_test_access_sends_bytes_body(self, mock_request):
+        service = Dropbox(camera_id=1)
+        service._location = '/backups'
+
+        result = service.test_access()
+
+        self.assertTrue(result)
+        # _request(url, body, headers) - positional, [0] is the args tuple
+        url, body, _headers = mock_request.call_args[0]
+        self.assertEqual(url, Dropbox.LIST_FOLDER_URL)
+        self.assertIsInstance(body, bytes)
+        self.assertEqual(json.loads(body.decode())['path'], '/backups')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

`Dropbox.test_access()` sent a **str** JSON body to `urllib`'s `Request`, which rejects it with:

```
POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str.
```

So testing/configuring the Dropbox upload service fails right after the OAuth handshake. This encodes the JSON body to `bytes`.

## Why

`uploadservices.py` `Dropbox.test_access()` built the list-folder request body with `json.dumps(body)` (a `str`) and passed it to `self._request()` → `Request(url, data=body)`. `urllib` requires `data` to be bytes. The credential paths (`_request_credentials` / `_refresh_credentials`) already `.encode()` their bodies, and `upload_data()` passes the raw binary file, so `test_access` was the only str-body path.

Fixes #2828 — confirmed by multiple reporters (the same `.encode()` fix was suggested in the thread).

## How

```python
-        body = json.dumps(body)
+        body = json.dumps(body).encode()
```

## Testing

- New `tests/test_uploadservices_dropbox.py` asserts `test_access()` sends a `bytes` body to `_request` (and that it round-trips to the expected JSON).
- Full suite green: **117 passed** (Linux). `ruff check` / `ruff format --check` pass.

## Notes / out of scope

- A reporter also noted the test-result UI then shows `Accessing the upload service succeeded![object Object]` — a separate cosmetic JS message-handling issue, not addressed here.
- `GooglePhoto` builds some request bodies with `json.dumps(...)` without `.encode()` as well; left untouched since it's a different service (and Google OOB OAuth has its own issues), but it may warrant a follow-up.

Closes #2828
