### PR TITLE
Send a User-Agent header when calling webhooks

### DIFF
--- a/motioneye/webhook.py
+++ b/motioneye/webhook.py
@@ -42,7 +42,8 @@ def main(parser, args):
     logging.debug('method = %s' % options.method)
     logging.debug('url = %s' % options.url)
 
-    headers = {}
+    # some endpoints reject requests without a User-Agent with HTTP 403
+    headers = {'User-Agent': 'motionEye'}
     parts = urllib.parse.urlparse(options.url)
     url = options.url
     data = None


### PR DESCRIPTION
## What

motionEye builds the webhook request without a `User-Agent` header. Endpoints that reject user-agent-less requests respond with **HTTP 403**, so the webhook appears "not called" even though the request is actually made (it just fails). Reporters confirmed the request reaches the server and only fails on the missing UA (works fine from Postman / curl).

## Why

In `webhook.py` the request headers only ever contained `Content-Type` (for the POST variants), never a `User-Agent`. A number of APIs / WAFs block requests with no UA.

## How

Set a default `User-Agent: motionEye` header for **all** webhook methods (`GET` / `POST` / `POSTf` / `POSTj`), mirroring the UA that `utils/rtsp.py` already sends. The per-method `Content-Type` headers are preserved.

```diff
-    headers = {}
+    # some endpoints reject requests without a User-Agent with HTTP 403
+    headers = {'User-Agent': 'motionEye'}
```

## Testing

- `webhook.py` compiles; verified the resulting header dict carries `User-Agent: motionEye` for every method while keeping the correct `Content-Type`.

Fixes #2704
Fixes #2573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
