### PR TITLE
enh(relay): send the relay API a path relative to the camera dir

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1447,7 +1447,10 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
     data['on_event_end'] = '; '.join(on_event_end)
 
     # movie end
-    on_movie_end = [f"{meyectl.find_command('relayevent')} movie_end %t %f"]
+    # the trailing target_dir lets relayevent.sh send a path relative to it
+    on_movie_end = [
+        f"{meyectl.find_command('relayevent')} movie_end %t %f '{data['target_dir']}'"
+    ]
 
     if ui['web_hook_storage_enabled']:
         url = sub('\\s', '+', ui['web_hook_storage_url'])
@@ -1466,7 +1469,10 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
     data['on_movie_end'] = '; '.join(on_movie_end)
 
     # picture save
-    on_picture_save = [f"{meyectl.find_command('relayevent')} picture_save %t %f"]
+    # the trailing target_dir lets relayevent.sh send a path relative to it
+    on_picture_save = [
+        f"{meyectl.find_command('relayevent')} picture_save %t %f '{data['target_dir']}'"
+    ]
 
     if ui['web_hook_storage_enabled']:
         url = sub('\\s', '+', ui['web_hook_storage_url'])

--- a/motioneye/handlers/relay_event.py
+++ b/motioneye/handlers/relay_event.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from os import sep
+import os
 from typing import Optional
 
 from motioneye import config, mediafiles, motionctl, tasks, uploadservices, utils
@@ -73,10 +73,11 @@ class RelayEventHandler(BaseHandler):
         filename: Optional[str] = self.get_argument('filename')
         if filename is not None:
             target_dir: str = camera_config['target_dir']
-            utils.validate_paths(
-                utils.remove_prefix(filename, target_dir + sep),
-                target_dir=target_dir,
-            )
+            # the relay script sends a path relative to the camera dir;
+            # remove_prefix also tolerates a legacy absolute path coming from an
+            # un-regenerated motion config
+            filename = utils.remove_prefix(filename, target_dir + os.sep)
+            utils.validate_paths(filename, target_dir=target_dir)
 
         if event == 'start':
             if not camera_config['@motion_detection']:
@@ -98,7 +99,7 @@ class RelayEventHandler(BaseHandler):
                 mediafiles.make_movie_preview,
                 tag='make_movie_preview(%s)' % filename,
                 camera_config=camera_config,
-                full_path=filename,
+                rel_path=filename,
             )
 
             # upload to external service
@@ -127,7 +128,8 @@ class RelayEventHandler(BaseHandler):
             camera_name=camera_config['camera_name'],
             target_dir=camera_config['@upload_subfolders']
             and camera_config['target_dir'],
-            filename=filename,
+            # the upload subsystem still works with the absolute path
+            filename=os.path.join(camera_config['target_dir'], filename),
             media_type=media_type,
             clean_uploaded=camera_config['@clean_uploaded'],
         )

--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -450,7 +450,11 @@ def get_movie_duration_seconds(path: str) -> int:
         return 0
 
 
-def make_movie_preview(camera_config: dict, full_path: str) -> Optional[str]:
+def make_movie_preview(camera_config: dict, rel_path: str) -> Optional[str]:
+    target_dir: str = camera_config['target_dir']
+    utils.validate_paths(rel_path, target_dir=target_dir)
+    full_path = os.path.join(target_dir, rel_path)
+
     framerate = camera_config['framerate']
     pre_capture = camera_config['pre_capture']
     offs = pre_capture / framerate
@@ -461,12 +465,6 @@ def make_movie_preview(camera_config: dict, full_path: str) -> Optional[str]:
 
     path = quote(full_path)
     thumb_path = full_path + '.thumb'
-
-    target_dir: str = camera_config['target_dir']
-    utils.validate_paths(
-        utils.remove_prefix(full_path, target_dir + os.sep),
-        target_dir=target_dir,
-    )
 
     logging.debug(
         f'creating movie preview for {full_path} with an offset of {offs} seconds...'
@@ -912,7 +910,7 @@ def get_media_preview(camera_config, path: str, media_type, width, height):
             # have already been created by the thumbnailer task;
             # if, for some reason that's not the case,
             # we create it right away
-            if not make_movie_preview(camera_config, full_path):
+            if not make_movie_preview(camera_config, path):
                 return None
 
         full_path += '.thumb'

--- a/motioneye/scripts/relayevent.sh
+++ b/motioneye/scripts/relayevent.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 if [ -z "$3" ]; then
-    echo "Usage: $0 <motioneye.conf> <event> <motion_camera_id> [filename]"
+    echo "Usage: $0 <motioneye.conf> <event> <motion_camera_id> [filename] [camera_dir]"
     exit 1
 fi
 
@@ -24,6 +24,15 @@ fi
 event=$2
 motion_camera_id=$3
 filename=$4
+camera_dir=$5
+
+# send the API a path relative to the camera dir (POSIX prefix strip). Guard
+# against an empty camera_dir - e.g. an old motion config calling a newer
+# script - so we never strip a bare leading "/". If the prefix does not match,
+# the filename is left unchanged and the API still validates it.
+if [ -n "$camera_dir" ]; then
+    filename=${filename#"$camera_dir"/}
+fi
 
 uri="/_relay_event/?event=$event&motion_camera_id=$motion_camera_id"
 data="{\"filename\": \"$filename\"}"

--- a/tests/test_mediafiles.py
+++ b/tests/test_mediafiles.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from time import time
+from unittest.mock import patch
 
 from motioneye import mediafiles
 from motioneye.mediafiles import _list_media_files
@@ -341,11 +342,11 @@ class TestMediaFilesPathValidation(unittest.TestCase):
     # --- make_movie_preview ---
 
     def test_make_movie_preview_rejects_traversal(self):
+        # make_movie_preview now takes a path relative to the camera dir
         for path in self._FILENAME_TRAVERSALS:
-            full_path = os.path.join(self._camera_config['target_dir'], path)
-            with self.subTest(full_path=full_path):
+            with self.subTest(path=path):
                 self._assert_raises_traversal(
-                    mediafiles.make_movie_preview, self._camera_config, full_path
+                    mediafiles.make_movie_preview, self._camera_config, path
                 )
 
     def test_make_movie_preview_rejects_absolute_path(self):
@@ -355,12 +356,32 @@ class TestMediaFilesPathValidation(unittest.TestCase):
                     mediafiles.make_movie_preview, self._camera_config, path
                 )
 
+    def test_make_movie_preview_reconstructs_absolute_path(self):
+        # a valid relative path is joined back onto target_dir for ffmpeg
+        rel_path = 'group/movie.mp4'
+        expected_full = os.path.join(self._camera_config['target_dir'], rel_path)
+        captured = {}
+
+        def fake_call_subprocess(cmd, **kwargs):
+            captured['cmd'] = cmd
+            return ''
+
+        with patch(
+            'motioneye.mediafiles.get_movie_duration_seconds', return_value=10.0
+        ), patch('motioneye.utils.call_subprocess', side_effect=fake_call_subprocess):
+            # the thumbnail is never actually written, so it returns None, but
+            # the ffmpeg command must reference the reconstructed absolute path
+            mediafiles.make_movie_preview(self._camera_config, rel_path)
+
+        self.assertIn('cmd', captured)
+        self.assertIn(expected_full, ' '.join(captured['cmd']))
+
     def test_make_movie_preview_rejects_dir_escape(self):
+        # make_movie_preview now takes a path relative to the camera dir
         for path in self._FILENAME_ESCAPES:
-            full_path = os.path.join(self._camera_config['target_dir'], path)
-            with self.subTest(full_path=full_path):
+            with self.subTest(path=path):
                 self._assert_raises_dir_escape(
-                    mediafiles.make_movie_preview, self._camera_config, full_path
+                    mediafiles.make_movie_preview, self._camera_config, path
                 )
 
     # --- list_media ---


### PR DESCRIPTION
## What

Make the relay-event API receive a path **relative to the camera dir** instead of the absolute `%f` path `motion` passes. `relayevent.sh` strips the camera dir before posting, so the validation-oriented path slicing in `relay_event.py` and `mediafiles.make_movie_preview` is no longer needed.

Implements the idea @MichaIng raised in #3374 ("I would actually prefer if the API itself would take a relative path ... split off the camera dir in `relayevent.sh`").

## How

- **`scripts/relayevent.sh`** — takes an optional `camera_dir` arg and strips it from the filename (`${filename#"$camera_dir"/}`). Guarded against an empty/non-matching value, so a stale absolute path is left untouched and still validated server-side.
- **`config.py`** — the generated `on_movie_end` / `on_picture_save` commands now pass the camera's `target_dir` (single-quoted) as that argument. `target_dir` is already known where the command is built; `motion` has no conversion specifier for it.
- **`handlers/relay_event.py`** — the incoming `filename` is now relative. `remove_prefix` still tolerates a legacy absolute path (un-regenerated motion config), then it's validated directly. The absolute path is reconstructed only for the upload call, so the upload subsystem is unchanged.
- **`mediafiles.make_movie_preview`** — now takes a relative path, validates it, and reconstructs the absolute path internally; `get_media_preview` passes the relative path it already had (dropping a redundant `os.path.join`).

## Scope / not included

The upload services (`UploadService.upload_file`, incl. the S3 override) still receive an **absolute** path and keep deriving the cloud-relative name themselves — that derivation is cloud-path naming tied to `@upload_subfolders`, a separate concern from the validation slicing this PR removes. Relativizing it (and the broader "every API endpoint takes relative paths") would be a follow-up. Builds on the now-merged #3374 (`utils.remove_prefix`).

## Testing

- Full suite green in a Linux container: **128 passed**.
- `tests/test_mediafiles.py`: the `make_movie_preview` traversal/escape validation tests now pass **relative** malicious paths (the form the API actually receives); added a test asserting the absolute path is reconstructed (`os.path.join(target_dir, rel_path)`) for ffmpeg.
- `shellcheck -o all` passes on `relayevent.sh`; verified the prefix-strip with a shell harness (matching prefix → relative, non-matching → unchanged, spaces handled, empty `camera_dir` → no bare-slash strip).
- `ruff check` / `ruff format --check` pass.
- Note: an end-to-end run (real `motion` + camera) wasn't possible in my environment.
