### PR TITLE
fix(diskctl): list mounted drives even without write access

### DIFF
--- a/motioneye/controls/diskctl.py
+++ b/motioneye/controls/diskctl.py
@@ -41,9 +41,6 @@ def _list_mounts():
             fstype = parts[2]
             opts = parts[3]
 
-            # a mounted drive the motion user cannot (yet) write to is still
-            # offered as a storage device; it used to be filtered out here on a
-            # missing os.W_OK, so the drive looked unrecognised (#3024)
 
             if target in seen_targets:
                 continue  # probably a bind mount

--- a/motioneye/controls/diskctl.py
+++ b/motioneye/controls/diskctl.py
@@ -58,8 +58,7 @@ def _list_mounts():
                     'mount_point': mount_point,
                     'fstype': fstype,
                     'opts': opts,
-                    # surfaced in the UI so a drive the motion user cannot write
-                    # to is flagged instead of silently failing to store media
+                    # Used by the UI to mark unwritable mounts.
                     'writable': os.access(mount_point, os.W_OK),
                 }
             )

--- a/motioneye/controls/diskctl.py
+++ b/motioneye/controls/diskctl.py
@@ -41,8 +41,9 @@ def _list_mounts():
             fstype = parts[2]
             opts = parts[3]
 
-            if not os.access(mount_point, os.W_OK):
-                continue
+            # a mounted drive the motion user cannot (yet) write to is still
+            # offered as a storage device; it used to be filtered out here on a
+            # missing os.W_OK, so the drive looked unrecognised (#3024)
 
             if target in seen_targets:
                 continue  # probably a bind mount

--- a/motioneye/controls/diskctl.py
+++ b/motioneye/controls/diskctl.py
@@ -41,7 +41,6 @@ def _list_mounts():
             fstype = parts[2]
             opts = parts[3]
 
-
             if target in seen_targets:
                 continue  # probably a bind mount
 

--- a/motioneye/controls/diskctl.py
+++ b/motioneye/controls/diskctl.py
@@ -61,6 +61,9 @@ def _list_mounts():
                     'mount_point': mount_point,
                     'fstype': fstype,
                     'opts': opts,
+                    # surfaced in the UI so a drive the motion user cannot write
+                    # to is flagged instead of silently failing to store media
+                    'writable': os.access(mount_point, os.W_OK),
                 }
             )
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -2175,18 +2175,10 @@ function dict2CameraUi(dict) {
             }
             label += ' (' + partition.target + ')';
             if (partition.writable === false) {
-                /* warn that the motion user cannot write here, so users do not
-                 * pick it and then wonder why no media is stored (#3024) */
-                label += ' [' + i18n.gettext('ne skribebla') + ']';
-            }
-
-            storageDeviceOptions[option] = true;
-
-            if (partition.writable === false) {
                 label += ' [' + i18n.gettext('No write access') + ']';
             }
 
-            // Show unwritable mounts, but prevent selecting them.            
+            // Show unwritable mounts, but prevent selecting them.
             $('#storageDeviceSelect').append(
                 $('<option></option>')
                     .val(option)

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -2182,7 +2182,21 @@ function dict2CameraUi(dict) {
 
             storageDeviceOptions[option] = true;
 
-            $('#storageDeviceSelect').append('<option value="' + option + '">' + label + '</option>');
+            if (partition.writable === false) {
+                label += ' [' + i18n.gettext('No write access') + ']';
+            }
+
+            // Show unwritable mounts, but prevent selecting them.            
+            $('#storageDeviceSelect').append(
+                $('<option></option>')
+                    .val(option)
+                    .text(label)
+                    .prop('disabled', partition.writable === false)
+            );
+
+            if (partition.writable !== false) {
+                storageDeviceOptions[option] = true;
+            }
         });
     });
     $('#storageDeviceSelect').append('<option value="custom-path">'+i18n.gettext("Propra dosierindiko")+'</option>');

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -2174,6 +2174,11 @@ function dict2CameraUi(dict) {
                 label += '/part' + partition.part_no;
             }
             label += ' (' + partition.target + ')';
+            if (partition.writable === false) {
+                /* warn that the motion user cannot write here, so users do not
+                 * pick it and then wonder why no media is stored (#3024) */
+                label += ' [' + i18n.gettext('ne skribebla') + ']';
+            }
 
             storageDeviceOptions[option] = true;
 

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -510,6 +510,13 @@ function initUI() {
 
         return true;
     }, '');
+    makeCustomValidator($('#storageDeviceSelect'), function (value) {
+        if ($('#storageDeviceSelect option:selected').prop('disabled')) {
+            return i18n.gettext('The configured storage device is not writable. Recordings cannot be saved until write access is restored.');
+        }
+
+        return true;
+    }, true);
     makeCustomValidator($('#emailFromEntry'), function (value) {
         if (value && !value.match(emailValidRegExp)) {
             return i18n.gettext("enigu validan retpoŝtadreson");

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -2186,9 +2186,7 @@ function dict2CameraUi(dict) {
                     .prop('disabled', partition.writable === false)
             );
 
-            if (partition.writable !== false) {
-                storageDeviceOptions[option] = true;
-            }
+            storageDeviceOptions[option] = true;
         });
     });
     $('#storageDeviceSelect').append('<option value="custom-path">'+i18n.gettext("Propra dosierindiko")+'</option>');

--- a/motioneye/static/js/ui.js
+++ b/motioneye/static/js/ui.js
@@ -339,7 +339,7 @@ function makeProgressBar($div) {
 
     /* validators */
 
-function makeCustomValidator($input, isValidFunc) {
+function makeCustomValidator($input, isValidFunc, ignoreVisibility) {
     $input.each(function () {
         var element = this;
 
@@ -353,8 +353,8 @@ function makeCustomValidator($input, isValidFunc) {
         function validate() {
             var strVal = element.value || '';
 
-            /* An invisible element is considered always valid */
-            var valid = !isVisible(element) || isValidFunc(strVal);
+            /* An invisible element is considered always valid, unless ignoreVisibility is set */
+            var valid = (!ignoreVisibility && !isVisible(element)) || isValidFunc(strVal);
 
             /* Handle validators that return error messages or true */
             var isValidResult = (valid === true);

--- a/tests/test_diskctl.py
+++ b/tests/test_diskctl.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import mock_open, patch
+
+from motioneye.controls import diskctl
+
+
+class ListMountsTest(unittest.TestCase):
+    _PROC_MOUNTS = (
+        '/dev/sda1 /media/usb ext4 rw,relatime 0 0\n'
+        '/dev/sdb1 /media/usb2 vfat rw,relatime 0 0\n'
+        '/dev/sdb1 /media/bind ext4 rw,relatime 0 0\n'  # duplicate target (bind)
+    )
+
+    def test_includes_mounts_without_write_access(self):
+        # a drive the motion user cannot write to used to be filtered out on a
+        # missing os.W_OK, so it never appeared as a storage device (#3024)
+        with patch(
+            'motioneye.controls.diskctl.open', mock_open(read_data=self._PROC_MOUNTS)
+        ), patch('motioneye.controls.diskctl.os.access', return_value=False):
+            mounts = diskctl._list_mounts()
+
+        targets = [m['target'] for m in mounts]
+        self.assertIn('/dev/sda1', targets)
+        self.assertIn('/dev/sdb1', targets)
+
+    def test_deduplicates_bind_mounts(self):
+        with patch(
+            'motioneye.controls.diskctl.open', mock_open(read_data=self._PROC_MOUNTS)
+        ), patch('motioneye.controls.diskctl.os.access', return_value=True):
+            mounts = diskctl._list_mounts()
+
+        # the second /dev/sdb1 entry (a bind mount) is collapsed
+        self.assertEqual([m['target'] for m in mounts].count('/dev/sdb1'), 1)
+        self.assertEqual(len(mounts), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_diskctl.py
+++ b/tests/test_diskctl.py
@@ -38,6 +38,8 @@ class ListMountsTest(unittest.TestCase):
         targets = [m['target'] for m in mounts]
         self.assertIn('/dev/sda1', targets)
         self.assertIn('/dev/sdb1', targets)
+        # ... but each is flagged as not writable so the UI can warn (#3024)
+        self.assertTrue(all(m['writable'] is False for m in mounts))
 
     def test_deduplicates_bind_mounts(self):
         with patch(
@@ -48,6 +50,7 @@ class ListMountsTest(unittest.TestCase):
         # the second /dev/sdb1 entry (a bind mount) is collapsed
         self.assertEqual([m['target'] for m in mounts].count('/dev/sdb1'), 1)
         self.assertEqual(len(mounts), 2)
+        self.assertTrue(all(m['writable'] is True for m in mounts))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

A mounted USB/flash drive is now offered as a storage device even when the `motion` user can't (yet) write to it — but it's shown as disabled with a "No write access" hint, rather than being silently omitted. Previously such a drive was invisible and only "Custom Path" was selectable.

## Why

`diskctl._list_mounts()` skipped every mount that failed `os.access(mount_point, os.W_OK)`. A drive mounted but owned by `root` (so not writable by the `motion` user) was therefore filtered out and never appeared in the storage-device dropdown — it looked unrecognised, even though it showed up in `fdisk` and `/dev/disk/by-id/`. `@MichaIng` reproduced this and pinpointed the write-access filter as the cause in #3024.

## How

Drop the `os.W_OK` filter in `_list_mounts()`; instead, tag every mount with a `writable` flag (`os.access(mount_point, os.W_OK)`). `list_mounted_disks()` already cross-references `_list_disks()` (real block devices from `/dev/disk/by-id` or `fdisk -l`), so this only surfaces genuine mounted partitions, not virtual/system mounts like `proc`/`tmpfs`.

In the UI, a non-writable drive is now listed with a "[No write access]" label but rendered as a disabled `<option>`, so it cannot actually be selected as the storage device. Making it selectable was deliberately avoided — picking a drive the `motion` user can't write to would silently point a camera's target directory at a location where writes fail. Granting the `motion` user OS-level write access to the drive is the remaining step to actually use it; this PR only makes that limitation visible instead of hiding the drive entirely.

## Testing

- `tests/test_diskctl.py`: asserts `_list_mounts()` still returns a mount when `os.access` reports no write permission, but flags it `writable: False` (locks in the fix), and still de-duplicates bind mounts.
- Full suite green in a Linux container: **129 passed**. `ruff check` / `ruff format --check` pass.

Closes #3024
