### PR TITLE
fix(sendmail): do not report a delivered email as failed when quit() fails

### DIFF
--- a/motioneye/sendmail.py
+++ b/motioneye/sendmail.py
@@ -72,7 +72,15 @@ def send_mail(server, port, account, password, tls, _from, to, subject, message,
 
     logging.debug('sending email message')
     conn.sendmail(_from, to, email.as_string())
-    conn.quit()
+
+    try:
+        conn.quit()
+
+    except (smtplib.SMTPException, OSError) as e:
+        # the message was already accepted by the server above; some servers
+        # (e.g. Gmail) drop the connection right after, so quit() fails - that
+        # must not be reported as a send failure (#3125)
+        logging.warning(f'failed to cleanly close the SMTP connection: {e}')
 
 
 def make_message(subject, message, camera_id, moment, timespan, callback):

--- a/tests/test_sendmail.py
+++ b/tests/test_sendmail.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2013 Calin Crisan
+# This file is part of motionEye.
+#
+# motionEye is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import smtplib
+import unittest
+from unittest.mock import patch
+
+from motioneye import sendmail
+
+_ARGS = ('smtp.example', 25, '', '', False, 'a@example', ['b@example'])
+_KW = {'subject': 'subj', 'message': 'msg', 'files': []}
+
+
+class SendMailTest(unittest.TestCase):
+    @patch('motioneye.sendmail.smtplib.SMTP')
+    def test_quit_failure_is_not_a_send_failure(self, mock_smtp):
+        conn = mock_smtp.return_value
+        conn.quit.side_effect = smtplib.SMTPServerDisconnected('connection closed')
+
+        # the message was accepted by sendmail(); a failing quit() (e.g. Gmail
+        # dropping the connection) must not be reported as a send failure (#3125)
+        sendmail.send_mail(*_ARGS, **_KW)
+
+        conn.sendmail.assert_called_once()
+        conn.quit.assert_called_once()
+
+    @patch('motioneye.sendmail.smtplib.SMTP')
+    def test_send_failure_propagates(self, mock_smtp):
+        conn = mock_smtp.return_value
+        conn.sendmail.side_effect = smtplib.SMTPRecipientsRefused(
+            {'b@example': (550, b'no')}
+        )
+
+        # a real failure while sending must still propagate to the caller
+        with self.assertRaises(smtplib.SMTPException):
+            sendmail.send_mail(*_ARGS, **_KW)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

The "Test Email" button (and notification emails) reported **failure** even when the email was actually delivered. This guards the SMTP connection teardown so a successful send is no longer reported as failed.

## Why

In `sendmail.send_mail()`:

```python
conn.sendmail(_from, to, email.as_string())   # the message is sent here
conn.quit()                                   # connection teardown
```

`conn.sendmail()` is what actually delivers the message. `conn.quit()` is just cleanup, but some SMTP servers (notably **Gmail**) drop the connection right after accepting the message, so `quit()` raises `SMTPServerDisconnected`. The config handler catches *any* exception from `send_mail()` and shows `"Notification email failed:"` — even though the email already arrived.

This matches the issue exactly: as @zagrim noted, _"I get 'Notification email failed:' when clicking 'Test Email', but I still do get the email in my inbox."_ (The separate Gmail "less secure apps" angle is user-side.)

## How

Wrap `conn.quit()` in a `try/except (smtplib.SMTPException, OSError)` and only log a warning — the message was already accepted by `sendmail()` above, so a teardown failure must not be treated as a send failure. A genuine failure during `sendmail()` still propagates.

## Testing

- New `tests/test_sendmail.py`: a failing `quit()` does **not** raise (send is still considered successful), while a failure in `sendmail()` **does** propagate.
- Full suite green in a Linux container: **129 passed**. `ruff check` / `ruff format --check` pass.

Closes #3125
