### PR TITLE
fix(ui): avoid stacking media dialog playback handlers

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -3635,22 +3635,22 @@ function runPictureDialog(entries, pos, mediaType, onDelete) {
 
         if (playable) {
             video_loader.attr('src', basePath + mediaType + '/' + entry.cameraId + '/playback' + entry.path);
-            playButton.on('click', function() {
+            playButton.off('click.pictureDialog').on('click.pictureDialog', function() {
                 video_container.attr('src', basePath + mediaType + '/' + entry.cameraId + '/playback' + entry.path);
                 video_container.show();
                 video_container.get(0).load();  /* Must call load() after changing <video> source */
                 img.hide();
                 playButton.hide();
                 timelapseButton.hide();
-                video_container.on('canplay', function() {
+                video_container.off('canplay.pictureDialog').one('canplay.pictureDialog', function() {
                    video_container.get(0).play();  /* Automatically play the video once the browser is ready */
                 });
             });
 
-            timelapseButton.on('click', function() {
+            timelapseButton.off('click.pictureDialog').on('click.pictureDialog', function() {
                 playButton.trigger('click');
                 mPlayer.playbackRate = 5;
-                video_container.on('ended', function() {
+                video_container.off('ended.pictureDialog').on('ended.pictureDialog', function() {
                     if( pos > 0 ) {
                         nextArrow.trigger('click');
                         playButton.trigger('click');

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -3686,7 +3686,7 @@ function runPictureDialog(entries, pos, mediaType, onDelete) {
         playButton.trigger('click');
         video_container.get(0).playbackRate = 5;
         video_container.off('ended.pictureDialog').on('ended.pictureDialog', function() {
-            if( pos > 0 ) {
+            if (pos > 0) {
                 nextArrow.trigger('click');
                 playButton.trigger('click');
                 video_container.get(0).playbackRate = 5;

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -3621,7 +3621,6 @@ function runPictureDialog(entries, pos, mediaType, onDelete) {
         prevArrow.css('display', 'none');
         nextArrow.css('display', 'none');
 
-        var mPlayer = document.getElementById('mPlayer');
         var playable = video_container.get(0).canPlayType(entry.mimeType) != '';
         timelapseButton.hide();
         playButton.hide();
@@ -3635,30 +3634,6 @@ function runPictureDialog(entries, pos, mediaType, onDelete) {
 
         if (playable) {
             video_loader.attr('src', basePath + mediaType + '/' + entry.cameraId + '/playback' + entry.path);
-            playButton.off('click.pictureDialog').on('click.pictureDialog', function() {
-                video_container.attr('src', basePath + mediaType + '/' + entry.cameraId + '/playback' + entry.path);
-                video_container.show();
-                video_container.get(0).load();  /* Must call load() after changing <video> source */
-                img.hide();
-                playButton.hide();
-                timelapseButton.hide();
-                video_container.off('canplay.pictureDialog').one('canplay.pictureDialog', function() {
-                   video_container.get(0).play();  /* Automatically play the video once the browser is ready */
-                });
-            });
-
-            timelapseButton.off('click.pictureDialog').on('click.pictureDialog', function() {
-                playButton.trigger('click');
-                mPlayer.playbackRate = 5;
-                video_container.off('ended.pictureDialog').on('ended.pictureDialog', function() {
-                    if( pos > 0 ) {
-                        nextArrow.trigger('click');
-                        playButton.trigger('click');
-                        mPlayer.playbackRate = 5;
-                    }
-                });
-            });
-
             playButton.show();
             timelapseButton.show();
         }
@@ -3688,6 +3663,36 @@ function runPictureDialog(entries, pos, mediaType, onDelete) {
         modalContainer.find('span.modal-title:last').html(entry.name);
         updateModalDialogPosition();
     }
+
+    /* the handlers are registered once per dialog and read entries[pos] at
+     * click time, so they always act on the currently displayed file */
+    playButton.on('click', function() {
+        var entry = entries[pos];
+        if (video_container.get(0).canPlayType(entry.mimeType) == '') {
+            return;  /* the timelapse chain may trigger this on a non-playable entry */
+        }
+        video_container.attr('src', basePath + mediaType + '/' + entry.cameraId + '/playback' + entry.path);
+        video_container.show();
+        video_container.get(0).load();  /* Must call load() after changing <video> source */
+        img.hide();
+        playButton.hide();
+        timelapseButton.hide();
+        video_container.off('canplay.pictureDialog').one('canplay.pictureDialog', function() {
+           video_container.get(0).play();  /* Automatically play the video once the browser is ready */
+        });
+    });
+
+    timelapseButton.on('click', function() {
+        playButton.trigger('click');
+        video_container.get(0).playbackRate = 5;
+        video_container.off('ended.pictureDialog').on('ended.pictureDialog', function() {
+            if( pos > 0 ) {
+                nextArrow.trigger('click');
+                playButton.trigger('click');
+                video_container.get(0).playbackRate = 5;
+            }
+        });
+    });
 
     prevArrow.on('click', function () {
         if (pos < entries.length - 1) {


### PR DESCRIPTION
## Summary
- prevent media dialog playback controls from stacking click handlers when navigating between videos
- reset video `canplay` and `ended` handlers with a `pictureDialog` namespace before registering new ones
- follow-up (c3a33d3, suggested by @Marijn0): register the `playButton`/`timelapseButton` click handlers once per dialog in `runPictureDialog()` instead of re-registering them on every `updatePicture()`; the handlers read `entries[pos]` at click time so they always act on the currently displayed file. A `canPlayType` guard protects the programmatic trigger from the timelapse chain when the current entry is not playable.

## Why
`updatePicture()` runs every time the user moves between media entries. It was adding new Play and Timelapse handlers each time, so Timelapse playback could trigger multiple next-video actions after repeated navigation.

Fixes #3375.

## Validation
- Checked the diff is limited to `motioneye/static/js/main.js`; `node --check` passes
- Verified the video-element `canplay`/`ended` handlers use `pictureDialog` event namespaces
- E2E against a live motionEye server with two movie files in the media directory (Playwright, headless Chromium):
  - open the movies browser → open a movie → Play starts playback of the current entry
  - navigate to the other entry → Play switches the `<video>` source to that entry (click-time `entries[pos]` works)
  - jQuery `$._data(...).events` shows exactly **one** click handler on the Play button, before and after navigation (no stacking)
