### PR TITLE
fix(media): use pre-capture offset for movie previews

### DIFF
--- a/motioneye/mediafiles.py
+++ b/motioneye/mediafiles.py
@@ -428,36 +428,10 @@ def cleanup_media(media_type: str) -> None:
         )
 
 
-def get_movie_duration_seconds(path: str) -> int:
-    cmd = [
-        'ffprobe',
-        '-v',
-        'error',
-        '-show_entries',
-        'format=duration',
-        '-of',
-        'default=noprint_wrappers=1:nokey=1',
-        path,
-    ]
-
-    try:
-        result = utils.call_subprocess(cmd, stderr=None)
-        duration_seconds = int(float(result))
-        return duration_seconds
-
-    except Exception as e:
-        logging.error(f'failed to determine duration of {path}: {e}')
-        return 0
-
-
 def make_movie_preview(camera_config: dict, full_path: str) -> Optional[str]:
     framerate = camera_config['framerate']
     pre_capture = camera_config['pre_capture']
     offs = pre_capture / framerate
-    movie_duration = get_movie_duration_seconds(full_path)
-    offs = max(
-        (x for x in {offs * 2, offs} if x <= movie_duration), default=movie_duration / 2
-    )
 
     path = quote(full_path)
     thumb_path = full_path + '.thumb'

--- a/tests/test_mediafiles.py
+++ b/tests/test_mediafiles.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from time import time
+from unittest.mock import patch
 
 from motioneye import mediafiles
 from motioneye.mediafiles import _list_media_files
@@ -362,6 +363,25 @@ class TestMediaFilesPathValidation(unittest.TestCase):
                 self._assert_raises_dir_escape(
                     mediafiles.make_movie_preview, self._camera_config, full_path
                 )
+
+    @patch('motioneye.mediafiles.utils.call_subprocess')
+    def test_make_movie_preview_uses_pre_capture_offset(self, mock_call_subprocess):
+        full_path = os.path.join(self._target_dir, 'movie.mp4')
+        thumb_path = full_path + '.thumb'
+        Path(full_path).touch()
+        Path(thumb_path).write_bytes(b'thumb')
+
+        camera_config = {
+            'target_dir': self._target_dir,
+            'framerate': 10,
+            'pre_capture': 40,
+        }
+
+        result = mediafiles.make_movie_preview(camera_config, full_path)
+
+        self.assertEqual(result, thumb_path)
+        command = mock_call_subprocess.call_args[0][0]
+        self.assertEqual(command[command.index('-ss') + 1], '4.0')
 
     # --- list_media ---
 


### PR DESCRIPTION
## Summary
- use the configured pre-capture offset directly when creating movie preview thumbnails
- remove the empirical doubled-offset/duration selection logic
- add a unit test for the `pre_capture / framerate` thumbnail offset

## Why
The old logic preferred `pre_capture / framerate * 2` when it fit within the video duration, which could place thumbnails several seconds after the actual motion event. The configured pre-capture value already identifies where the event begins in the recorded movie.

Fixes #2766.

## Validation
- `python3 -m py_compile motioneye/mediafiles.py tests/test_mediafiles.py`
- Could not run the unittest target locally because the environment is missing `tornado`, imported by the test package
