### PR TITLE
fix(config): translate boolean netcam_params correctly

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -29,7 +29,7 @@ from secrets import token_hex
 from shlex import split
 from stat import S_IMODE
 from subprocess import STDOUT
-from typing import Optional
+from typing import Optional, Union
 from urllib.parse import quote, urlunparse
 
 from argon2 import PasswordHasher
@@ -192,50 +192,47 @@ _MOTION_43_TO_41_OPTIONS_MAPPING = {
 }
 
 
-def netcam_keepalive_params(v, data):
+def netcam_keepalive_params(v: Union[bool, str], data: dict) -> dict:
     # value can be 'force' as well
-    v = 'on' if v == True else 'off' if v == False else v  # noqa: E712
+    value: str = 'on' if v == True else 'force' if v == 'force' else 'off'
 
     if 'netcam_params' in data and data['netcam_params']:
-        return {'netcam_params': data['netcam_params'] + ',keepalive = ' + v}
+        return {'netcam_params': data['netcam_params'] + ',keepalive = ' + value}
 
-    return {'netcam_params': 'keepalive = ' + v}
-
-
-def netcam_tolerant_check_params(v, data):
-    v = 'on' if v else 'off'
-
-    if 'netcam_params' in data and data['netcam_params']:
-        return {'netcam_params': data['netcam_params'] + ',tolerant_check = ' + v}
-
-    return {'netcam_params': 'tolerant_check = ' + v}
+    return {'netcam_params': 'keepalive = ' + value}
 
 
-def netcam_use_tcp_params(v, data):
-    v = 'tcp' if v else 'udp'
+def netcam_tolerant_check_params(v: bool, data: dict) -> dict:
+    value: str = 'on' if v else 'off'
 
     if 'netcam_params' in data and data['netcam_params']:
-        return {'netcam_params': data['netcam_params'] + ',rtsp_transport = ' + v}
+        return {'netcam_params': data['netcam_params'] + ',tolerant_check = ' + value}
 
-    return {'netcam_params': 'rtsp_transport = ' + v}
+    return {'netcam_params': 'tolerant_check = ' + value}
 
 
-def netcam_params(v, data):
-    params = {}
+def netcam_use_tcp_params(v: bool, data: dict) -> dict:
+    value: str = 'tcp' if v else 'udp'
+
+    if 'netcam_params' in data and data['netcam_params']:
+        return {'netcam_params': data['netcam_params'] + ',rtsp_transport = ' + value}
+
+    return {'netcam_params': 'rtsp_transport = ' + value}
+
+
+def netcam_params(v: str, data: dict) -> dict:
+    params: dict = {}
     for param in v.split(','):
         param = [x.strip() for x in param.split('=')]
         if param[0] == 'keepalive':
-            params['netcam_keepalive'] = param[1]
+            # value can be 'force' as well
+            params['netcam_keepalive'] = True if param[1] == 'on' else 'force' if param[1] == 'force' else False
 
         elif param[0] == 'tolerant_check':
-            params['netcam_tolerant_check'] = param[1]
+            params['netcam_tolerant_check'] = True if param[1] == 'on' else False
 
         elif param[0] == 'rtsp_transport':
-            if param[1] == 'udp':
-                params['netcam_use_tcp'] = False
-
-            else:
-                params['netcam_use_tcp'] = True
+            params['netcam_use_tcp'] = False if param[1] == 'udp' else True
 
     return params
 

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -223,16 +223,18 @@ def netcam_use_tcp_params(v: bool, data: dict) -> dict:
 def netcam_params(v: str, data: dict) -> dict:
     params: dict = {}
     for param in v.split(','):
-        param = [x.strip() for x in param.split('=')]
-        if param[0] == 'keepalive':
+        split = [x.strip() for x in param.split('=')]
+        if split[0] == 'keepalive':
             # value can be 'force' as well
-            params['netcam_keepalive'] = True if param[1] == 'on' else 'force' if param[1] == 'force' else False
+            params['netcam_keepalive'] = (
+                True if split[1] == 'on' else 'force' if split[1] == 'force' else False
+            )
 
-        elif param[0] == 'tolerant_check':
-            params['netcam_tolerant_check'] = True if param[1] == 'on' else False
+        elif split[0] == 'tolerant_check':
+            params['netcam_tolerant_check'] = True if split[1] == 'on' else False
 
-        elif param[0] == 'rtsp_transport':
-            params['netcam_use_tcp'] = False if param[1] == 'udp' else True
+        elif split[0] == 'rtsp_transport':
+            params['netcam_use_tcp'] = False if split[1] == 'udp' else True
 
     return params
 

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -193,8 +193,7 @@ _MOTION_43_TO_41_OPTIONS_MAPPING = {
 
 
 def netcam_keepalive_params(v: Union[bool, str], data: dict) -> dict:
-    # value can be 'force' as well
-    value: str = 'on' if v == True else 'force' if v == 'force' else 'off'
+    value: str = 'on' if v == True else 'force' if v == 'force' else 'off'  # noqa: E712
 
     if 'netcam_params' in data and data['netcam_params']:
         return {'netcam_params': data['netcam_params'] + ',keepalive = ' + value}
@@ -225,7 +224,6 @@ def netcam_params(v: str, data: dict) -> dict:
     for param in v.split(','):
         split = [x.strip() for x in param.split('=')]
         if split[0] == 'keepalive':
-            # value can be 'force' as well
             params['netcam_keepalive'] = (
                 True if split[1] == 'on' else 'force' if split[1] == 'force' else False
             )

--- a/motioneye/locale/motioneye.js.pot
+++ b/motioneye/locale/motioneye.js.pot
@@ -143,488 +143,492 @@ msgstr ""
 msgid "enigu validan valoron"
 msgstr ""
 
-#: motioneye/static/js/main.js:698
+#: motioneye/static/js/main.js:701
 msgid "Ĉi rekursie forigos ĉiujn dosierojn ĉeestantajn en la nuba dosierujo \""
 msgstr ""
 
-#: motioneye/static/js/main.js:699
+#: motioneye/static/js/main.js:702
 msgid "\", ne nur tiuj alŝutitaj de motionEye!"
 msgstr ""
 
-#: motioneye/static/js/main.js:790
+#: motioneye/static/js/main.js:711
+msgid "\"Purigi la nubon\" estis malŝaltita ĉar ĝi konfliktas kun \"Forigi Dosierojn Post Alŝuto\"."
+msgstr ""
+
+#: motioneye/static/js/main.js:802
 msgid "Ĉi rekursie forigos ĉiujn malnovajn amaskomunikilajn dosierojn en la dosierujo \""
 msgstr ""
 
-#: motioneye/static/js/main.js:791
+#: motioneye/static/js/main.js:803
 msgid "\", ne nur tiuj kreitaj de motionEye!"
 msgstr ""
 
-#: motioneye/static/js/main.js:871
+#: motioneye/static/js/main.js:883
 msgid "Ne eblas redakti la maskon sen valida kameraa bildo!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2132
+#: motioneye/static/js/main.js:2145
 msgid "Propra"
 msgstr ""
 
-#: motioneye/static/js/main.js:2170
+#: motioneye/static/js/main.js:2183
 msgid "Propra dosierindiko"
 msgstr ""
 
-#: motioneye/static/js/main.js:2172
+#: motioneye/static/js/main.js:2185
 msgid "Retan kunlokon"
 msgstr ""
 
-#: motioneye/static/js/main.js:2528
+#: motioneye/static/js/main.js:2542
 msgid "Via retumilo ne efektivigas ĉi tiun funkcion!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2544
+#: motioneye/static/js/main.js:2558
 msgid "Apliki"
 msgstr ""
 
-#: motioneye/static/js/main.js:2571 motioneye/static/js/main.js:2887
-#: motioneye/static/js/main.js:2943 motioneye/static/js/main.js:3018
+#: motioneye/static/js/main.js:2585 motioneye/static/js/main.js:2901
+#: motioneye/static/js/main.js:2957 motioneye/static/js/main.js:3032
 msgid "Certigu, ke ĉiuj agordaj opcioj validas!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2625
+#: motioneye/static/js/main.js:2639
 msgid "Admin password updated. Please log in again."
 msgstr ""
 
-#: motioneye/static/js/main.js:2679
+#: motioneye/static/js/main.js:2693
 msgid "Ĉi tio rekomencos la sistemon. Daŭrigi?"
 msgstr ""
 
-#: motioneye/static/js/main.js:2689
+#: motioneye/static/js/main.js:2703
 msgid "Vere fermiti sistemon?"
 msgstr ""
 
-#: motioneye/static/js/main.js:2701
+#: motioneye/static/js/main.js:2715
 msgid "Malŝaltita"
 msgstr ""
 
-#: motioneye/static/js/main.js:2716
+#: motioneye/static/js/main.js:2730
 msgid "Ĉu vere restartigi ?"
 msgstr ""
 
-#: motioneye/static/js/main.js:2730
+#: motioneye/static/js/main.js:2744
 msgid "La sistemo rekomencis!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2750 motioneye/static/js/main.js:3762
-#: motioneye/static/js/main.js:4092
+#: motioneye/static/js/main.js:2764 motioneye/static/js/main.js:3776
+#: motioneye/static/js/main.js:4106
 msgid "Bonvolu apliki unue la modifitajn agordojn!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2755
+#: motioneye/static/js/main.js:2769
 msgid "Neniu fotilo por forigi!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2761
+#: motioneye/static/js/main.js:2775
 msgid "Ĉu forigi kameraon "
 msgstr ""
 
-#: motioneye/static/js/main.js:2789
+#: motioneye/static/js/main.js:2803
 msgid "Rezerva dosiero"
 msgstr ""
 
-#: motioneye/static/js/main.js:2791
+#: motioneye/static/js/main.js:2805
 msgid "La rezervan dosieron, kiun vi antaŭe elŝutis."
 msgstr ""
 
-#: motioneye/static/js/main.js:2820
+#: motioneye/static/js/main.js:2834
 msgid "Restaŭrigi Agordon"
 msgstr ""
 
-#: motioneye/static/js/main.js:2832
+#: motioneye/static/js/main.js:2846
 msgid "Restaŭriganta agordon ..."
 msgstr ""
 
-#: motioneye/static/js/main.js:2839
+#: motioneye/static/js/main.js:2853
 msgid "La agordo restaŭrigis!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2849 motioneye/static/js/main.js:2868
+#: motioneye/static/js/main.js:2863 motioneye/static/js/main.js:2882
 msgid "Malsukcesis restaŭri la agordon!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2924
+#: motioneye/static/js/main.js:2938
 msgid "Aliri la alŝutan servon malsukcesis: "
 msgstr ""
 
-#: motioneye/static/js/main.js:2927
+#: motioneye/static/js/main.js:2941
 msgid "Aliri la alŝutan servon sukcesis!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2964
+#: motioneye/static/js/main.js:2978
 msgid "Sciiga retpoŝto fiaskis:"
 msgstr ""
 
-#: motioneye/static/js/main.js:2967
+#: motioneye/static/js/main.js:2981
 msgid "Notification email succeeded!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2983
+#: motioneye/static/js/main.js:2997
 msgid "Certiĝu, ke ĉiuj agordaj opcioj estas validaj!"
 msgstr ""
 
-#: motioneye/static/js/main.js:2999
+#: motioneye/static/js/main.js:3013
 msgid "Sciiga Telegramo fiaskis:"
 msgstr ""
 
-#: motioneye/static/js/main.js:3002
+#: motioneye/static/js/main.js:3016
 msgid "Sciiga Telegramo sukcesis!"
 msgstr ""
 
-#: motioneye/static/js/main.js:3038
+#: motioneye/static/js/main.js:3052
 msgid "Aliro al retdividado fiaskis: "
 msgstr ""
 
-#: motioneye/static/js/main.js:3041
+#: motioneye/static/js/main.js:3055
 msgid "Aliro al retdividado sukcesis!"
 msgstr ""
 
-#: motioneye/static/js/main.js:3065
+#: motioneye/static/js/main.js:3079
 msgid "Ĉu vere forigi ĉi tiun dosieron?"
 msgstr ""
 
-#: motioneye/static/js/main.js:3089
+#: motioneye/static/js/main.js:3103
 msgid "Ĉu vere forigi ĉiujn bildojn de \"%(group)s\"?"
 msgstr ""
 
-#: motioneye/static/js/main.js:3092
+#: motioneye/static/js/main.js:3106
 msgid "Ĉu vere forigi ĉiujn filmojn de \"%(group)s\"?"
 msgstr ""
 
-#: motioneye/static/js/main.js:3097
+#: motioneye/static/js/main.js:3111
 msgid "Ĉu vere forigi ĉiujn ne grupigitajn bildojn?"
 msgstr ""
 
-#: motioneye/static/js/main.js:3100
+#: motioneye/static/js/main.js:3114
 msgid "Ĉu vere forigi ĉiujn ne grupigitajn filmojn?"
 msgstr ""
 
-#: motioneye/static/js/main.js:3212
+#: motioneye/static/js/main.js:3226
 msgid "aldonadi kameraon..."
 msgstr ""
 
-#: motioneye/static/js/main.js:3443 motioneye/static/js/main.js:3784
-#: motioneye/static/js/main.js:4105
+#: motioneye/static/js/main.js:3457 motioneye/static/js/main.js:3798
+#: motioneye/static/js/main.js:4119
 msgid "Uzantnomo"
 msgstr ""
 
-#: motioneye/static/js/main.js:3448 motioneye/static/js/main.js:3789
-#: motioneye/static/js/main.js:4110
+#: motioneye/static/js/main.js:3462 motioneye/static/js/main.js:3803
+#: motioneye/static/js/main.js:4124
 msgid "Pasvorto"
 msgstr ""
 
-#: motioneye/static/js/main.js:3460
+#: motioneye/static/js/main.js:3474
 msgid "Please login to continue."
 msgstr ""
 
-#: motioneye/static/js/main.js:3464 motioneye/static/js/main.js:3468
+#: motioneye/static/js/main.js:3478 motioneye/static/js/main.js:3482
 msgid "Ensaluti"
 msgstr ""
 
-#: motioneye/static/js/main.js:3467 motioneye/static/js/ui.js:736
+#: motioneye/static/js/main.js:3481 motioneye/static/js/ui.js:736
 #: motioneye/static/js/ui.js:743
 msgid "Nuligi"
 msgstr ""
 
-#: motioneye/static/js/main.js:3495
+#: motioneye/static/js/main.js:3509
 msgid "Your account requires a password to be set. Please contact the administrator to set a password for your account."
 msgstr ""
 
-#: motioneye/static/js/main.js:3508
+#: motioneye/static/js/main.js:3522
 msgid "Please set a password for your account."
 msgstr ""
 
-#: motioneye/static/js/main.js:3525
+#: motioneye/static/js/main.js:3539
 msgid "Login failed."
 msgstr ""
 
-#: motioneye/static/js/main.js:3559
+#: motioneye/static/js/main.js:3573
 msgid "Vi abortis la filmeton."
 msgstr ""
 
-#: motioneye/static/js/main.js:3562
+#: motioneye/static/js/main.js:3576
 msgid "Reto eraro okazis."
 msgstr ""
 
-#: motioneye/static/js/main.js:3565
+#: motioneye/static/js/main.js:3579
 msgid "Malkodado-eraro aŭ neprogresinta funkcio."
 msgstr ""
 
-#: motioneye/static/js/main.js:3568
+#: motioneye/static/js/main.js:3582
 msgid "Formato ne subtenata aŭ neatingebla/netaŭga por ludado."
 msgstr ""
 
-#: motioneye/static/js/main.js:3571
+#: motioneye/static/js/main.js:3585
 msgid "Nekonata eraro okazis."
 msgstr ""
 
-#: motioneye/static/js/main.js:3574
+#: motioneye/static/js/main.js:3588
 msgid "Eraro : "
 msgstr ""
 
-#: motioneye/static/js/main.js:3579
+#: motioneye/static/js/main.js:3593
 msgid "antaŭa bildo"
 msgstr ""
 
-#: motioneye/static/js/main.js:3584
+#: motioneye/static/js/main.js:3598
 msgid "ludi"
 msgstr ""
 
-#: motioneye/static/js/main.js:3587
+#: motioneye/static/js/main.js:3601
 msgid "ludi * 5 kaj enĉenigi"
 msgstr ""
 
-#: motioneye/static/js/main.js:3592
+#: motioneye/static/js/main.js:3606
 msgid "sekva bildo"
 msgstr ""
 
-#: motioneye/static/js/main.js:3715
+#: motioneye/static/js/main.js:3729
 msgid "Fermi"
 msgstr ""
 
-#: motioneye/static/js/main.js:3716 motioneye/static/js/main.js:4368
+#: motioneye/static/js/main.js:3730 motioneye/static/js/main.js:4382
 msgid "Elŝuti"
 msgstr ""
 
-#: motioneye/static/js/main.js:3724 motioneye/static/js/main.js:4371
+#: motioneye/static/js/main.js:3738 motioneye/static/js/main.js:4385
 msgid "Forigi"
 msgstr ""
 
-#: motioneye/static/js/main.js:3768
+#: motioneye/static/js/main.js:3782
 msgid "Kamerao tipo"
 msgstr ""
 
-#: motioneye/static/js/main.js:3770
+#: motioneye/static/js/main.js:3784
 msgid "Loka V4L2-kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3771
+#: motioneye/static/js/main.js:3785
 msgid "Loka MMAL-kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3772
+#: motioneye/static/js/main.js:3786
 msgid "Reta kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3773
+#: motioneye/static/js/main.js:3787
 msgid "Fora motionEye kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3774
+#: motioneye/static/js/main.js:3788
 msgid "Simpla MJPEG-kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3776
+#: motioneye/static/js/main.js:3790
 msgid "la speco de kamerao, kiun vi volas aldoni"
 msgstr ""
 
-#: motioneye/static/js/main.js:3779 motioneye/static/js/main.js:4097
+#: motioneye/static/js/main.js:3793 motioneye/static/js/main.js:4111
 msgid "URL"
 msgstr ""
 
-#: motioneye/static/js/main.js:3780 motioneye/static/js/main.js:4098
+#: motioneye/static/js/main.js:3794 motioneye/static/js/main.js:4112
 msgid "http://ekzemplo.com:8765/cams/..."
 msgstr ""
 
-#: motioneye/static/js/main.js:3781 motioneye/static/js/main.js:4099
+#: motioneye/static/js/main.js:3795 motioneye/static/js/main.js:4113
 msgid "la kameraa URL (ekz. http://ekzemplo.com:8080/cam/)"
 msgstr ""
 
-#: motioneye/static/js/main.js:3785 motioneye/static/js/main.js:4106
+#: motioneye/static/js/main.js:3799 motioneye/static/js/main.js:4120
 msgid "uzantnomo..."
 msgstr ""
 
-#: motioneye/static/js/main.js:3786
+#: motioneye/static/js/main.js:3800
 msgid "la uzantnomo por la URL, se bezonata (ekz. administranto)"
 msgstr ""
 
-#: motioneye/static/js/main.js:3790 motioneye/static/js/main.js:4111
+#: motioneye/static/js/main.js:3804 motioneye/static/js/main.js:4125
 msgid "pasvorto..."
 msgstr ""
 
-#: motioneye/static/js/main.js:3791
+#: motioneye/static/js/main.js:3805
 msgid "la pasvorto por la URL, se bezonata"
 msgstr ""
 
-#: motioneye/static/js/main.js:3794 motioneye/static/js/main.js:4118
+#: motioneye/static/js/main.js:3808 motioneye/static/js/main.js:4132
 msgid "Remote Secret"
 msgstr ""
 
-#: motioneye/static/js/main.js:3795 motioneye/static/js/main.js:4119
+#: motioneye/static/js/main.js:3809 motioneye/static/js/main.js:4133
 msgid "remote secret..."
 msgstr ""
 
-#: motioneye/static/js/main.js:3796
+#: motioneye/static/js/main.js:3810
 msgid "the client secret of the remote motionEye server. Find this value in the Client Secret field of the remote server's general settings."
 msgstr ""
 
-#: motioneye/static/js/main.js:3799
+#: motioneye/static/js/main.js:3813
 msgid "Kamerao"
 msgstr ""
 
-#: motioneye/static/js/main.js:3801
+#: motioneye/static/js/main.js:3815
 msgid "la kameraon, kiun vi volas aldoni"
 msgstr ""
 
-#: motioneye/static/js/main.js:3835
+#: motioneye/static/js/main.js:3849
 msgid "Fora motionEye kamerao estas kameraoj instalitaj malantaŭ alia servilo de MotionEye. Aldonante ilin ĉi tie permesos vin rigardi kaj administri ilin de malproksime."
 msgstr ""
 
-#: motioneye/static/js/main.js:3848
+#: motioneye/static/js/main.js:3862
 msgid "Retaj kameraoj (aŭ IP-kameraoj) estas aparatoj, kiuj denaske fluas RTSP/RTMP aŭ MJPEG-filmetojn aŭ simplajn JPEG-bildojn. Konsultu la manlibron de via aparato por ekscii la ĝustan URL RTSP, RTMP, MJPEG aŭ JPEG."
 msgstr ""
 
-#: motioneye/static/js/main.js:3853
+#: motioneye/static/js/main.js:3867
 msgid "Lokaj MMAL-kameraoj estas aparatoj konektitaj rekte al via motionEye-sistemo. Ĉi tiuj estas kutime kart-specifaj kameraoj."
 msgstr ""
 
-#: motioneye/static/js/main.js:3866
+#: motioneye/static/js/main.js:3880
 msgid "Aldonante vian aparaton kiel simplan MJPEG-kameraon anstataŭ kiel retan kameraon plibonigos la fotografaĵon, sed neniu moviĝo-detekto, bilda kaptado aŭ registrado de filmoj estos disponebla por ĝi. La kamerao devas esti alirebla por via servilo kaj via retumilo. Ĉi tiu tipo de kamerao ne kongruas kun Internet Explorer."
 msgstr ""
 
-#: motioneye/static/js/main.js:3871
+#: motioneye/static/js/main.js:3885
 msgid "Lokaj V4L2-kameraoj estas kameraaj aparatoj konektitaj rekte al via motionEye-sistemo, kutime per USB."
 msgstr ""
 
-#: motioneye/static/js/main.js:4024
+#: motioneye/static/js/main.js:4038
 msgid "Aldonadi kameraon..."
 msgstr ""
 
-#: motioneye/static/js/main.js:4107 motioneye/static/js/main.js:4112
+#: motioneye/static/js/main.js:4121 motioneye/static/js/main.js:4126
 msgid "leave both empty to keep the current username and password"
 msgstr ""
 
-#: motioneye/static/js/main.js:4120
+#: motioneye/static/js/main.js:4134
 msgid "leave empty to keep the current remote secret"
 msgstr ""
 
-#: motioneye/static/js/main.js:4135
+#: motioneye/static/js/main.js:4149
 msgid "Edit connection information"
 msgstr ""
 
-#: motioneye/static/js/main.js:4186
+#: motioneye/static/js/main.js:4200
 msgid "Grupo"
 msgstr ""
 
-#: motioneye/static/js/main.js:4190
+#: motioneye/static/js/main.js:4204
 msgid "Inkluzivi foton prenitan ĉiun"
 msgstr ""
 
-#: motioneye/static/js/main.js:4193
+#: motioneye/static/js/main.js:4207
 msgid "sekundo"
 msgstr ""
 
-#: motioneye/static/js/main.js:4194
+#: motioneye/static/js/main.js:4208
 msgid "5 sekundoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4195
+#: motioneye/static/js/main.js:4209
 msgid "10 sekundoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4196
+#: motioneye/static/js/main.js:4210
 msgid "30 sekundoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4197
+#: motioneye/static/js/main.js:4211
 msgid "minuto"
 msgstr ""
 
-#: motioneye/static/js/main.js:4198
+#: motioneye/static/js/main.js:4212
 msgid "5 minutoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4199
+#: motioneye/static/js/main.js:4213
 msgid "10 minutoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4200
+#: motioneye/static/js/main.js:4214
 msgid "30 minutoj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4201
+#: motioneye/static/js/main.js:4215
 msgid "horo"
 msgstr ""
 
-#: motioneye/static/js/main.js:4204
+#: motioneye/static/js/main.js:4218
 msgid "Elektu la intervalon de tempo inter du elektitaj bildoj."
 msgstr ""
 
-#: motioneye/static/js/main.js:4207
+#: motioneye/static/js/main.js:4221
 msgid "Filmo framfrekvenco"
 msgstr ""
 
-#: motioneye/static/js/main.js:4209
+#: motioneye/static/js/main.js:4223
 msgid "Elektu kiom rapide vi volas ke la akselita video estu."
 msgstr ""
 
-#: motioneye/static/js/main.js:4218
+#: motioneye/static/js/main.js:4232
 msgid "Konsiderante la grandan nombron da bildoj, krei vian video povus daŭri iom da tempo!"
 msgstr ""
 
-#: motioneye/static/js/main.js:4235
+#: motioneye/static/js/main.js:4249
 msgid "Krei akselita video"
 msgstr ""
 
-#: motioneye/static/js/main.js:4244
+#: motioneye/static/js/main.js:4258
 msgid "Filmo kreanta en progreso..."
 msgstr ""
 
-#: motioneye/static/js/main.js:4495
+#: motioneye/static/js/main.js:4509
 msgid "Zipitaj"
 msgstr ""
 
-#: motioneye/static/js/main.js:4504
+#: motioneye/static/js/main.js:4518
 msgid "Akselita video"
 msgstr ""
 
-#: motioneye/static/js/main.js:4515
+#: motioneye/static/js/main.js:4529
 msgid "Forigi ĉiujn"
 msgstr ""
 
-#: motioneye/static/js/main.js:4657
+#: motioneye/static/js/main.js:4671
 msgid "Bildoj prenitaj de "
 msgstr ""
 
-#: motioneye/static/js/main.js:4660
+#: motioneye/static/js/main.js:4674
 msgid "Filmoj registritaj de "
 msgstr ""
 
-#: motioneye/static/js/main.js:4728
+#: motioneye/static/js/main.js:4742
 msgid "montru ĉi tiun fotilon plenekranan"
 msgstr ""
 
-#: motioneye/static/js/main.js:4729
+#: motioneye/static/js/main.js:4743
 msgid "montri ĉiujn fotilojn"
 msgstr ""
 
-#: motioneye/static/js/main.js:4730
+#: motioneye/static/js/main.js:4744
 msgid "montru nur ĉi tiun fotilon"
 msgstr ""
 
-#: motioneye/static/js/main.js:4731
+#: motioneye/static/js/main.js:4745
 msgid "malfermaj bildoj retumilo"
 msgstr ""
 
-#: motioneye/static/js/main.js:4732
+#: motioneye/static/js/main.js:4746
 msgid "malferma videoj retumilo"
 msgstr ""
 
-#: motioneye/static/js/main.js:4733
+#: motioneye/static/js/main.js:4747
 msgid "agordi ĉi tiun kameraon"
 msgstr ""
 
-#: motioneye/static/js/main.js:4749
+#: motioneye/static/js/main.js:4763
 msgid "preni instantaron"
 msgstr ""
 
-#: motioneye/static/js/main.js:5142
+#: motioneye/static/js/main.js:5156
 msgid "Vi ankoraŭ ne agordis iun kameraon. Alklaku ĉi tie por aldoni unu ..."
 msgstr ""
 

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:957
+#: motioneye/config.py:954
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:961
+#: motioneye/config.py:958
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %I %p %l %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:966
+#: motioneye/config.py:963
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:971
+#: motioneye/config.py:968
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:976
+#: motioneye/config.py:973
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgid "la uzantnomo uzata por agordi la sistemon"
 msgstr ""
 
 #: motioneye/templates/main.html:181 motioneye/templates/main.html:191
-#: motioneye/templates/main.html:534 motioneye/templates/main.html:722
+#: motioneye/templates/main.html:539 motioneye/templates/main.html:727
 msgid "Pasvorto"
 msgstr ""
 
@@ -267,8 +267,8 @@ msgstr ""
 msgid "Video-Aparato"
 msgstr ""
 
-#: motioneye/templates/main.html:274 motioneye/templates/main.html:632
-#: motioneye/templates/main.html:649
+#: motioneye/templates/main.html:274 motioneye/templates/main.html:637
+#: motioneye/templates/main.html:654
 msgid "Kamerao Nomo"
 msgstr ""
 
@@ -376,11 +376,11 @@ msgstr ""
 msgid "ebligas maskeradon de bildoj por eviti registradon de iuj bildaj areoj por protekti privatecon"
 msgstr ""
 
-#: motioneye/templates/main.html:359 motioneye/templates/main.html:1035
+#: motioneye/templates/main.html:359 motioneye/templates/main.html:1040
 msgid "Redakti maskon"
 msgstr ""
 
-#: motioneye/templates/main.html:360 motioneye/templates/main.html:1036
+#: motioneye/templates/main.html:360 motioneye/templates/main.html:1041
 msgid "Konservi maskon"
 msgstr ""
 
@@ -436,8 +436,8 @@ msgstr ""
 msgid "la nomo de la interŝanĝa reto"
 msgstr ""
 
-#: motioneye/templates/main.html:422 motioneye/templates/main.html:529
-#: motioneye/templates/main.html:717
+#: motioneye/templates/main.html:422 motioneye/templates/main.html:534
+#: motioneye/templates/main.html:722
 msgid "Uzantnomo"
 msgstr ""
 
@@ -589,951 +589,959 @@ msgstr ""
 msgid "ebligu ĉi tion forigi amaskomunikilaĵojn dosierojn alŝutitajn al la nubo ankaŭ kiam loka amaskomunikilaro estas forigita konforme al la agordo de persistemo de dosieroj. Nuntempe ĉi tiu opcio nur haveblas por gdrivo."
 msgstr ""
 
+#: motioneye/templates/main.html:529
+msgid "Forigi Dosierojn Post Alŝuto"
+msgstr ""
+
 #: motioneye/templates/main.html:531
-msgid "la uzantnomo por la alŝuta servo-konto"
+msgid "ebligu ĉi tion por forigi la lokan plurmedian dosieron tuj post kiam ĝi estis sukcese alŝutita al la ekstera servo (utila por liberigi malgrandajn SD-kartojn)"
 msgstr ""
 
 #: motioneye/templates/main.html:536
-msgid "la pasvorto por la alŝuta servo-konto"
-msgstr ""
-
-#: motioneye/templates/main.html:539
-msgid "Rajtiga ŝlosilo"
+msgid "la uzantnomo por la alŝuta servo-konto"
 msgstr ""
 
 #: motioneye/templates/main.html:541
+msgid "la pasvorto por la alŝuta servo-konto"
+msgstr ""
+
+#: motioneye/templates/main.html:544
+msgid "Rajtiga ŝlosilo"
+msgstr ""
+
+#: motioneye/templates/main.html:546
 msgid "la ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo (kutime bezonata nur dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:547
+#: motioneye/templates/main.html:552
 msgid "Akiri ŝlosilon"
 msgstr ""
 
-#: motioneye/templates/main.html:550
+#: motioneye/templates/main.html:555
 msgid "alklaku ĉi tie por akiri la ŝlosilan rajtigan servon"
 msgstr ""
 
-#: motioneye/templates/main.html:553
+#: motioneye/templates/main.html:558
 msgid "Access Key"
 msgstr ""
 
-#: motioneye/templates/main.html:555
+#: motioneye/templates/main.html:560
 msgid "The AWS access key used to authenticate with the upload service"
 msgstr ""
 
-#: motioneye/templates/main.html:558
+#: motioneye/templates/main.html:563
 msgid "Sekreta Alira Ŝlosilo"
 msgstr ""
 
-#: motioneye/templates/main.html:560
+#: motioneye/templates/main.html:565
 msgid "la AWS-sekreta alira ŝlosilo uzata por aŭtentiĝi kun la alŝuta servo (kutime bezonata nur dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:563
+#: motioneye/templates/main.html:568
 msgid "Sitelo"
 msgstr ""
 
-#: motioneye/templates/main.html:565
+#: motioneye/templates/main.html:570
 msgid "la nomo S3-sitelo por la alŝuta servo (kutime bezonata nur dum agordo)"
 msgstr ""
 
-#: motioneye/templates/main.html:568
+#: motioneye/templates/main.html:573
 msgid "Encryption key"
 msgstr ""
 
-#: motioneye/templates/main.html:569
+#: motioneye/templates/main.html:574
 msgid "optional base64-encoded SSE-C encryption key"
 msgstr ""
 
-#: motioneye/templates/main.html:570
+#: motioneye/templates/main.html:575
 msgid "Add an encryption key if you want to use server-side encryption (SSE-C). The key must be a base64-encoded string with a length of 32 bytes. This key will be needed by every client to access the encrypted files. You can generate a key using the following command: openssl rand 32 | base64"
 msgstr ""
 
-#: motioneye/templates/main.html:574
+#: motioneye/templates/main.html:579
 msgid "Testi la servon"
 msgstr ""
 
-#: motioneye/templates/main.html:575
+#: motioneye/templates/main.html:580
 msgid "alklaku ĉi tiun butonon por provi la alŝutan servon post kiam vi plenigis la postulatajn detalojn"
 msgstr ""
 
-#: motioneye/templates/main.html:581
+#: motioneye/templates/main.html:586
 msgid "alvoki URL"
 msgstr ""
 
-#: motioneye/templates/main.html:583
-msgid "ebligu ĉi tion, se vi volas, ke URL estu petata post kreado de amaskomunikila dosiero"
-msgstr ""
-
-#: motioneye/templates/main.html:586 motioneye/templates/main.html:1164
-#: motioneye/templates/main.html:1209
-msgid "Reteja URL"
-msgstr ""
-
-#: motioneye/templates/main.html:587
-msgid "ekz. http://example.com/notify/"
-msgstr ""
-
 #: motioneye/templates/main.html:588
-msgid "URL por transdoni kiam moviĝo estas detektita; la sekvaj specialaj ŝparvojoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero,%f = dosiera vojo"
+msgid "ebligu ĉi tion, se vi volas, ke URL estu petata post kreado de amaskomunikila dosiero"
 msgstr ""
 
 #: motioneye/templates/main.html:591 motioneye/templates/main.html:1169
 #: motioneye/templates/main.html:1214
+msgid "Reteja URL"
+msgstr ""
+
+#: motioneye/templates/main.html:592
+msgid "ekz. http://example.com/notify/"
+msgstr ""
+
+#: motioneye/templates/main.html:593
+msgid "URL por transdoni kiam moviĝo estas detektita; la sekvaj specialaj ŝparvojoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero,%f = dosiera vojo"
+msgstr ""
+
+#: motioneye/templates/main.html:596 motioneye/templates/main.html:1174
+#: motioneye/templates/main.html:1219
 msgid "Metodo HTTP"
 msgstr ""
 
-#: motioneye/templates/main.html:600
+#: motioneye/templates/main.html:605
 msgid "la HTTP-metodo por uzi kiam vi petas retan hoko-URL (la donitaj URL-koditaj parametroj fakte estos transdonitaj kiel indikite ĉi tie)"
 msgstr ""
 
-#: motioneye/templates/main.html:606
+#: motioneye/templates/main.html:611
 msgid "Kuri Komando"
 msgstr ""
 
-#: motioneye/templates/main.html:608
+#: motioneye/templates/main.html:613
 msgid "ebligu ĉi tion, se vi volas ekzekuti komandon post kiam media dosiero estas kreita"
 msgstr ""
 
-#: motioneye/templates/main.html:611
+#: motioneye/templates/main.html:616
 msgid "Ordono"
 msgstr ""
 
-#: motioneye/templates/main.html:612
+#: motioneye/templates/main.html:617
 msgid "ordono…"
 msgstr ""
 
-#: motioneye/templates/main.html:613
+#: motioneye/templates/main.html:618
 msgid "Komando por esti plenumita post la kreo de plurmedia dosiero. Pluraj komandoj povas esti apartigitaj per punktoknomo; ne uzu punktoknomo en komandojn; la sekvaj specialaj tokensoj estas akceptitaj: %Y = jaro, %m = monato, %d = tago, %H = horo, %M = minuto, %S = sekundo, %q = kadra numero , %v = okaza numero, %f = dosiera vojo"
 msgstr ""
 
-#: motioneye/templates/main.html:623
+#: motioneye/templates/main.html:628
 msgid "elektu kiajn informojn montras sur la kaptitaj kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:624
+#: motioneye/templates/main.html:629
 msgid "Teksto Superkovrita"
 msgstr ""
 
-#: motioneye/templates/main.html:629
+#: motioneye/templates/main.html:634
 msgid "Maldekstra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:633 motioneye/templates/main.html:650
+#: motioneye/templates/main.html:638 motioneye/templates/main.html:655
 msgid "Tempostampo"
 msgstr ""
 
-#: motioneye/templates/main.html:634 motioneye/templates/main.html:651
+#: motioneye/templates/main.html:639 motioneye/templates/main.html:656
 msgid "Propra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:635 motioneye/templates/main.html:652
-#: motioneye/templates/main.html:709
+#: motioneye/templates/main.html:640 motioneye/templates/main.html:657
+#: motioneye/templates/main.html:714
 msgid "Malebligita"
 msgstr ""
 
-#: motioneye/templates/main.html:638
+#: motioneye/templates/main.html:643
 msgid "Fiksas la tekston montritan sur la filmoj kaj bildoj, sur la malsupra maldekstra angulo"
 msgstr ""
 
-#: motioneye/templates/main.html:642 motioneye/templates/main.html:659
+#: motioneye/templates/main.html:647 motioneye/templates/main.html:664
 msgid "propra teksto…"
 msgstr ""
 
-#: motioneye/templates/main.html:643
+#: motioneye/templates/main.html:648
 msgid "Difinas kutimon maldekstran tekston; la sekvaj specialaj tokensoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero,%T = HH:MM:SS, \\n = nova linio"
 msgstr ""
 
-#: motioneye/templates/main.html:646
+#: motioneye/templates/main.html:651
 msgid "Dekstra Teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:655
+#: motioneye/templates/main.html:660
 msgid "Fiksas la tekston montritan sur la filmoj kaj bildoj, sur la malsupra dekstra angulo"
 msgstr ""
 
-#: motioneye/templates/main.html:660
+#: motioneye/templates/main.html:665
 msgid "Difinas kutimon dekstran tekston; la sekvaj specialaj tokensoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero,%T = HH:MM:SS, \\n = nova linio"
 msgstr ""
 
-#: motioneye/templates/main.html:663
+#: motioneye/templates/main.html:668
 msgid "Teksta Skalo"
 msgstr ""
 
-#: motioneye/templates/main.html:665
+#: motioneye/templates/main.html:670
 msgid "Difinas la grandecon de la superkovrita teksto"
 msgstr ""
 
-#: motioneye/templates/main.html:675
+#: motioneye/templates/main.html:680
 msgid "Ebligu ĉi tion, se vi volas videofluon por ĉi tiu fotilo"
 msgstr ""
 
-#: motioneye/templates/main.html:676
+#: motioneye/templates/main.html:681
 msgid "Videofluo"
 msgstr ""
 
-#: motioneye/templates/main.html:681
+#: motioneye/templates/main.html:686
 msgid "Framo frekvencon"
 msgstr ""
 
-#: motioneye/templates/main.html:683
+#: motioneye/templates/main.html:688
 msgid "Fiksas la nombron de kadroj transdonitaj ĉiun sekundon en la viva fluo."
 msgstr ""
 
-#: motioneye/templates/main.html:686
+#: motioneye/templates/main.html:691
 msgid "Flua Kvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:688
+#: motioneye/templates/main.html:693
 msgid "Agordas la vivan fluan kvaliton (pli altaj valoroj produktas pli bonan videokvaliton sed postulas pli da larĝa bando)."
 msgstr ""
 
-#: motioneye/templates/main.html:691
+#: motioneye/templates/main.html:696
 msgid "Bilda Redimensionado"
 msgstr ""
 
-#: motioneye/templates/main.html:693
+#: motioneye/templates/main.html:698
 msgid "Kiam ĉi tio estas enŝaltita, la bildoj estas regrandigitaj antaŭ ol ili estas senditaj al la retumilo (malebligu dum funkciado sur malrapida CPU)."
 msgstr ""
 
-#: motioneye/templates/main.html:696
+#: motioneye/templates/main.html:701
 msgid "Flua rezolucio"
 msgstr ""
 
-#: motioneye/templates/main.html:698
+#: motioneye/templates/main.html:703
 msgid "la rezolucio donita kiel procento de la rezolucio de la video-aparato (pli altaj valoroj produktas pli bonan videan kvaliton sed postulas pli da larĝa de bando)"
 msgstr ""
 
-#: motioneye/templates/main.html:701
+#: motioneye/templates/main.html:706
 msgid "Flua haveno"
 msgstr ""
 
-#: motioneye/templates/main.html:703
+#: motioneye/templates/main.html:708
 msgid "starigas la TCP-havenon, sur kiu aŭskultas la ret-servila ret-servo"
 msgstr ""
 
-#: motioneye/templates/main.html:706
+#: motioneye/templates/main.html:711
 msgid "Aŭtentiga reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:714
+#: motioneye/templates/main.html:719
 msgid "la aŭtentiga metodo uzata de la rivereto (elektu 'Bazic' anstataŭ 'Digest' se vi renkontas problemojn kun triaj programoj)"
 msgstr ""
 
-#: motioneye/templates/main.html:719
+#: motioneye/templates/main.html:724
 msgid "username used for video streaming authentication. When Admin-only access is enabled, use credentials different from the Surveillance user."
 msgstr ""
 
-#: motioneye/templates/main.html:724
+#: motioneye/templates/main.html:729
 msgid "password used for video streaming authentication. When Admin-only access is enabled, use credentials different from the Surveillance user."
 msgstr ""
 
-#: motioneye/templates/main.html:727
+#: motioneye/templates/main.html:732
 msgid "Movado-Optimigo"
 msgstr ""
 
-#: motioneye/templates/main.html:729
+#: motioneye/templates/main.html:734
 msgid "ebligu ĉi tion, se vi volas pli malaltan kadran indicon por la livera fluo kiam neniu movo estas detektita"
 msgstr ""
 
-#: motioneye/templates/main.html:735
+#: motioneye/templates/main.html:740
 msgid "Utilaj URLoj"
 msgstr ""
 
-#: motioneye/templates/main.html:738
+#: motioneye/templates/main.html:743
 msgid "Instantara URL"
 msgstr ""
 
-#: motioneye/templates/main.html:741
+#: motioneye/templates/main.html:746
 msgid "URL kiu provizas JPEG-bildon kun la plej freŝa kaptaĵo de la kamerao"
 msgstr ""
 
-#: motioneye/templates/main.html:747
+#: motioneye/templates/main.html:752
 msgid "Flua URL"
 msgstr ""
 
-#: motioneye/templates/main.html:750
+#: motioneye/templates/main.html:755
 msgid "URL kiu provizas MJPEG-fluon de la kamerao"
 msgstr ""
 
-#: motioneye/templates/main.html:756
+#: motioneye/templates/main.html:761
 msgid "Enigita URL"
 msgstr ""
 
-#: motioneye/templates/main.html:759
+#: motioneye/templates/main.html:764
 msgid "URL kiu provizas minimuman HTML-dokumenton enhavantan la kameraan kadron, preta por esti enigita"
 msgstr ""
 
-#: motioneye/templates/main.html:769
+#: motioneye/templates/main.html:774
 msgid "Ebligu ĉi tion, se vi volas kapti statika bildojn."
 msgstr ""
 
-#: motioneye/templates/main.html:770
+#: motioneye/templates/main.html:775
 msgid "Kaptitaj Bildoj"
 msgstr ""
 
-#: motioneye/templates/main.html:775
+#: motioneye/templates/main.html:780
 msgid "Nomo Bildo-Dosiero"
 msgstr ""
 
-#: motioneye/templates/main.html:776 motioneye/templates/main.html:845
+#: motioneye/templates/main.html:781 motioneye/templates/main.html:850
 msgid "dosiernomo ŝablono…"
 msgstr ""
 
-#: motioneye/templates/main.html:777
+#: motioneye/templates/main.html:782
 msgid "Difinas la nomon ŝablonon por bilddosieroj (JPEG); la sekvaj specialaj tokensoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero, / = subdosierujo."
 msgstr ""
 
-#: motioneye/templates/main.html:780
+#: motioneye/templates/main.html:785
 msgid "Bildkvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:782
+#: motioneye/templates/main.html:787
 msgid "agordas la JPEG-bildkvaliton (pli altaj valoroj produktas pli bonan bildan kvaliton sed postulas pli da stokado)"
 msgstr ""
 
-#: motioneye/templates/main.html:785
+#: motioneye/templates/main.html:790
 msgid "Kaptila reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:788 motioneye/templates/main.html:908
+#: motioneye/templates/main.html:793 motioneye/templates/main.html:913
 msgid "Moviĝa deĉenigo"
 msgstr ""
 
-#: motioneye/templates/main.html:789
+#: motioneye/templates/main.html:794
 msgid "Moviĝa deĉenigo (Unu bildo)"
 msgstr ""
 
-#: motioneye/templates/main.html:790
+#: motioneye/templates/main.html:795
 msgid "Intertempe"
 msgstr ""
 
-#: motioneye/templates/main.html:791
+#: motioneye/templates/main.html:796
 msgid "Ĉiuj bildoj"
 msgstr ""
 
-#: motioneye/templates/main.html:792
+#: motioneye/templates/main.html:797
 msgid "Mane"
 msgstr ""
 
-#: motioneye/templates/main.html:795
+#: motioneye/templates/main.html:800
 msgid "Difinas la kapta reĝimon:"
 msgstr ""
 
-#: motioneye/templates/main.html:796
+#: motioneye/templates/main.html:801
 msgid "Moviĝa deĉenigo = bildo kaptita ĉiufoje kiam moviĝo estas detektita,"
 msgstr ""
 
-#: motioneye/templates/main.html:797
+#: motioneye/templates/main.html:802
 msgid "Intertempe = bildo kaptita ĉiun x sekundojn,"
 msgstr ""
 
-#: motioneye/templates/main.html:798
+#: motioneye/templates/main.html:803
 msgid "Ĉiuj bildoj = konservas ĉiun kadron en bildodosiero,"
 msgstr ""
 
-#: motioneye/templates/main.html:799
+#: motioneye/templates/main.html:804
 msgid "Mane = mana kapto kun dediĉita butono."
 msgstr ""
 
-#: motioneye/templates/main.html:802
+#: motioneye/templates/main.html:807
 msgid "Interkapto-Intervalo"
 msgstr ""
 
-#: motioneye/templates/main.html:803 motioneye/templates/main.html:916
-#: motioneye/templates/main.html:991 motioneye/templates/main.html:1120
+#: motioneye/templates/main.html:808 motioneye/templates/main.html:921
+#: motioneye/templates/main.html:996 motioneye/templates/main.html:1125
 #: motioneye/utils/dtconv.py:155 motioneye/utils/dtconv.py:158
 msgid "sekundoj"
 msgstr ""
 
-#: motioneye/templates/main.html:804
+#: motioneye/templates/main.html:809
 msgid "agordas la intervalon (en sekundoj) por la kaptiloj"
 msgstr ""
 
-#: motioneye/templates/main.html:807
+#: motioneye/templates/main.html:812
 msgid "Konservi bildojn"
 msgstr ""
 
-#: motioneye/templates/main.html:810 motioneye/templates/main.html:923
+#: motioneye/templates/main.html:815 motioneye/templates/main.html:928
 msgid "Dum unu tago"
 msgstr ""
 
-#: motioneye/templates/main.html:811 motioneye/templates/main.html:924
+#: motioneye/templates/main.html:816 motioneye/templates/main.html:929
 msgid "Dum unu semajno"
 msgstr ""
 
-#: motioneye/templates/main.html:812 motioneye/templates/main.html:925
+#: motioneye/templates/main.html:817 motioneye/templates/main.html:930
 msgid "Dum unu monato"
 msgstr ""
 
-#: motioneye/templates/main.html:813 motioneye/templates/main.html:926
+#: motioneye/templates/main.html:818 motioneye/templates/main.html:931
 msgid "Dum unu jaro"
 msgstr ""
 
-#: motioneye/templates/main.html:814 motioneye/templates/main.html:927
+#: motioneye/templates/main.html:819 motioneye/templates/main.html:932
 msgid "Porĉiame"
 msgstr ""
 
-#: motioneye/templates/main.html:815 motioneye/templates/main.html:928
+#: motioneye/templates/main.html:820 motioneye/templates/main.html:933
 msgid "Propra"
 msgstr ""
 
-#: motioneye/templates/main.html:818
+#: motioneye/templates/main.html:823
 msgid "Bildoj pli aĝaj ol la difinita daŭro estas aŭtomate forigitaj por liberigi stokadan spacon."
 msgstr ""
 
-#: motioneye/templates/main.html:821
+#: motioneye/templates/main.html:826
 msgid "Bildaj Vivdaŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:823
+#: motioneye/templates/main.html:828
 msgid "Difinas la nombron da tagoj post kiuj la bildoj estos forigitaj aŭtomate."
 msgstr ""
 
-#: motioneye/templates/main.html:826
+#: motioneye/templates/main.html:831
 msgid "Ebligu manaj kaptoj"
 msgstr ""
 
-#: motioneye/templates/main.html:828
+#: motioneye/templates/main.html:833
 msgid "Kiam ĉi tio estas enŝaltita, butono sur la kameraa kadro permesos al vi permane preni kaptojn."
 msgstr ""
 
-#: motioneye/templates/main.html:838
+#: motioneye/templates/main.html:843
 msgid "ebligu ĉi tion, se vi volas registri filmojn"
 msgstr ""
 
-#: motioneye/templates/main.html:839
+#: motioneye/templates/main.html:844
 msgid "Filmoj"
 msgstr ""
 
-#: motioneye/templates/main.html:844
+#: motioneye/templates/main.html:849
 msgid "Filma Dosiernomo"
 msgstr ""
 
-#: motioneye/templates/main.html:846
+#: motioneye/templates/main.html:851
 msgid "Difinas la nomon ŝablonon por por la filmdosieroj; la sekvaj specialaj tokensoj estas akceptitaj:%Y = jaro,%m = monato,%d = tago,%H = horo,%M = minuto,%S = sekundo,%q = kadro numero,%v = evento numero, / = subdosierujo."
 msgstr ""
 
-#: motioneye/templates/main.html:849
+#: motioneye/templates/main.html:854
 msgid "Rekta kopia filmeto"
 msgstr ""
 
-#: motioneye/templates/main.html:851
+#: motioneye/templates/main.html:856
 msgid "Kreu filmojn rekte de la kamerao. Ĉi tiu opcio devus redukti CPU-uzadon sed pliigi memorpostulojn. Neniu bilda prilaborado estas farita, do tekstoj interkovras, privatecaj maskoj ktp. ne estos sur la rezulta video."
 msgstr ""
 
-#: motioneye/templates/main.html:854
+#: motioneye/templates/main.html:859
 msgid "Filmformato"
 msgstr ""
 
-#: motioneye/templates/main.html:897
+#: motioneye/templates/main.html:902
 msgid "Agordas la filmdosieron; ne ĉiuj formatoj garantias funkcii en ĉiuj sistemoj; se vi dubas, testu ĉiun formaton kaj elektu tiun, kiu plej bone funkcias per via filmetilo."
 msgstr ""
 
-#: motioneye/templates/main.html:900
+#: motioneye/templates/main.html:905
 msgid "Filma Kvalito"
 msgstr ""
 
-#: motioneye/templates/main.html:902
+#: motioneye/templates/main.html:907
 msgid "Agordas la MPEG-video-kvaliton (pli altaj valoroj produktas pli bonan videokvaliton sed postulas pli da stokado)."
 msgstr ""
 
-#: motioneye/templates/main.html:905
+#: motioneye/templates/main.html:910
 msgid "Rekorda reĝimo"
 msgstr ""
 
-#: motioneye/templates/main.html:909
+#: motioneye/templates/main.html:914
 msgid "Kontinua registrado"
 msgstr ""
 
-#: motioneye/templates/main.html:912
+#: motioneye/templates/main.html:917
 msgid "Agordas la registradreĝimon: Moviĝa deĉenigo = nova filmo kreita kiam ajn moviĝo estas detektita, Kontinua Registrado = unu granda filma dosiero."
 msgstr ""
 
-#: motioneye/templates/main.html:915
+#: motioneye/templates/main.html:920
 msgid "Maksimuma filma daŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:917
+#: motioneye/templates/main.html:922
 msgid "Agordas la maksimuman longon de filmoj en sekundoj; se la movada evento daŭras pli longe, nova filmdosiero estas kreita; uzu 0 por senlima longo."
 msgstr ""
 
-#: motioneye/templates/main.html:920
+#: motioneye/templates/main.html:925
 msgid "Konservi filmojn"
 msgstr ""
 
-#: motioneye/templates/main.html:931
+#: motioneye/templates/main.html:936
 msgid "Filmoj pli aĝaj ol la difinita daŭro estas aŭtomate forigitaj por liberigi stokadon."
 msgstr ""
 
-#: motioneye/templates/main.html:934
+#: motioneye/templates/main.html:939
 msgid "Filmoj Vivdaŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:935 motioneye/utils/dtconv.py:134
+#: motioneye/templates/main.html:940 motioneye/utils/dtconv.py:134
 msgid "tagoj"
 msgstr ""
 
-#: motioneye/templates/main.html:936
+#: motioneye/templates/main.html:941
 msgid "Agordas la nombron da tagoj post kiuj la filmoj estos forigitaj aŭtomate."
 msgstr ""
 
-#: motioneye/templates/main.html:946
+#: motioneye/templates/main.html:951
 msgid "Aktivigu ĉi tion, por uzi kaj agordi la mekanismon por detekti movadon."
 msgstr ""
 
-#: motioneye/templates/main.html:947
+#: motioneye/templates/main.html:952
 msgid "Movado-Detekto"
 msgstr ""
 
-#: motioneye/templates/main.html:952
+#: motioneye/templates/main.html:957
 msgid "Kadra ŝanĝo sojlo"
 msgstr ""
 
-#: motioneye/templates/main.html:954
+#: motioneye/templates/main.html:959
 msgid "Indikas la minimuman procenton de la bildo, kiu devas ŝanĝi inter du pluaj kadroj por detekti movadon (pli malgrandaj valoroj donas pli sentivan detekton, sed inklinas al falsaj pozitivoj)."
 msgstr ""
 
-#: motioneye/templates/main.html:957
+#: motioneye/templates/main.html:962
 msgid "Maksimuma ŝanĝo sojlo"
 msgstr ""
 
-#: motioneye/templates/main.html:959
+#: motioneye/templates/main.html:964
 msgid "Starigas la nombron da rastrumeroj ŝanĝitaj inter kadroj super kiuj movo ne plu ekigas (0 malŝaltas la limon)."
 msgstr ""
 
-#: motioneye/templates/main.html:962
+#: motioneye/templates/main.html:967
 msgid "Aŭtomata sojla agordo"
 msgstr ""
 
-#: motioneye/templates/main.html:964
+#: motioneye/templates/main.html:969
 msgid "Ebligu tion aŭtomate ĝustigi la sojlon."
 msgstr ""
 
-#: motioneye/templates/main.html:967
+#: motioneye/templates/main.html:972
 msgid "Aŭtomata bruo-detekto"
 msgstr ""
 
-#: motioneye/templates/main.html:969
+#: motioneye/templates/main.html:974
 msgid "Ebligu tion por aŭtomate ĝustigi la nivelon de bruo."
 msgstr ""
 
-#: motioneye/templates/main.html:972
+#: motioneye/templates/main.html:977
 msgid "Bruo-nivelo"
 msgstr ""
 
-#: motioneye/templates/main.html:974
+#: motioneye/templates/main.html:979
 msgid "Permane agordas la bruan nivelon al fiksita valoro."
 msgstr ""
 
-#: motioneye/templates/main.html:977
+#: motioneye/templates/main.html:982
 msgid "Detekto de lumaj ŝanĝoj"
 msgstr ""
 
-#: motioneye/templates/main.html:979
+#: motioneye/templates/main.html:984
 msgid "Difinas la procenton de la bildo, kiu bezonas ŝanĝi, por ke la evento estu traktata kiel subita luma ŝanĝo anstataŭ moviĝo (0% malebligas la funkcion)."
 msgstr ""
 
-#: motioneye/templates/main.html:982
+#: motioneye/templates/main.html:987
 msgid "Makula filtrilo"
 msgstr ""
 
-#: motioneye/templates/main.html:984
+#: motioneye/templates/main.html:989
 msgid "Ebligu tion apliki makulan filtrilon al kadroj antaŭ ol detekti movadon."
 msgstr ""
 
-#: motioneye/templates/main.html:990
+#: motioneye/templates/main.html:995
 msgid "Senmovada daŭro"
 msgstr ""
 
-#: motioneye/templates/main.html:992
+#: motioneye/templates/main.html:997
 msgid "Agordas la nombron da sekundoj da silento (t.e. neniu moviĝo), kiuj markas la finon de movada okazaĵo."
 msgstr ""
 
-#: motioneye/templates/main.html:995
+#: motioneye/templates/main.html:1000
 msgid "Kaptita Antaŭe"
 msgstr ""
 
-#: motioneye/templates/main.html:996 motioneye/templates/main.html:1001
-#: motioneye/templates/main.html:1006
+#: motioneye/templates/main.html:1001 motioneye/templates/main.html:1006
+#: motioneye/templates/main.html:1011
 msgid "kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:997
+#: motioneye/templates/main.html:1002
 msgid "Starigas la nombron de kadroj kaptitaj (kaj inkluzivitaj en la filmo) antaŭ ol moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1000
+#: motioneye/templates/main.html:1005
 msgid "Kaptita Post"
 msgstr ""
 
-#: motioneye/templates/main.html:1002
+#: motioneye/templates/main.html:1007
 msgid "Starigas la nombron de kadroj kaptotaj (kaj inkluzivitaj en la filmo) post la fino de movada evento."
 msgstr ""
 
-#: motioneye/templates/main.html:1005
+#: motioneye/templates/main.html:1010
 msgid "Minimumaj movaj kadroj"
 msgstr ""
 
-#: motioneye/templates/main.html:1007
+#: motioneye/templates/main.html:1012
 msgid "Fiksas la minimuman nombron da pluaj movaj kadroj necesaj por komenci moviĝan eventon."
 msgstr ""
 
-#: motioneye/templates/main.html:1013
+#: motioneye/templates/main.html:1018
 msgid "Masko"
 msgstr ""
 
-#: motioneye/templates/main.html:1015
+#: motioneye/templates/main.html:1020
 msgid "Ebligas bildigan maskeradon por pli selektema kaj preciza moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:1018
+#: motioneye/templates/main.html:1023
 msgid "Tipo de masko"
 msgstr ""
 
-#: motioneye/templates/main.html:1021
+#: motioneye/templates/main.html:1026
 msgid "Inteligenta"
 msgstr ""
 
-#: motioneye/templates/main.html:1022
+#: motioneye/templates/main.html:1027
 msgid "Redaktebla"
 msgstr ""
 
-#: motioneye/templates/main.html:1025
+#: motioneye/templates/main.html:1030
 msgid "La Inteligenta opcio aŭtomate detektas regionojn per regula movado kaj dinamike kreas internan maskon, dum la Redaktebla opcio permesas permane konstrui ĝin mem."
 msgstr ""
 
-#: motioneye/templates/main.html:1028
+#: motioneye/templates/main.html:1033
 msgid "Inteligenta-maska Malrapideco"
 msgstr ""
 
-#: motioneye/templates/main.html:1030
+#: motioneye/templates/main.html:1035
 msgid "Pli altaj valoroj donas pli daŭran maskon kun pli malrapida konstruprocezo."
 msgstr ""
 
-#: motioneye/templates/main.html:1039
+#: motioneye/templates/main.html:1044
 msgid "Alklaku ĉi tiun butonon por ebligi/malebligi la maskan redaktilon."
 msgstr ""
 
-#: motioneye/templates/main.html:1043
+#: motioneye/templates/main.html:1048
 msgid "Purigi maskon"
 msgstr ""
 
-#: motioneye/templates/main.html:1044
+#: motioneye/templates/main.html:1049
 msgid "Alklaku ĉi tiun butonon por malplenigi la nunan maskon."
 msgstr ""
 
-#: motioneye/templates/main.html:1050
+#: motioneye/templates/main.html:1055
 msgid "Montri Kadro-Ŝanĝojn"
 msgstr ""
 
-#: motioneye/templates/main.html:1052
+#: motioneye/templates/main.html:1057
 msgid "Se ĉi tio estas aktiva, la bilda ŝanĝojn (nombro de pikseloj kaj la modifita areo) estas montritaj en la video; provizore ebligigu ĉi tion por ĝustigi agordojn de moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:1055
+#: motioneye/templates/main.html:1060
 msgid "Krei debug media files"
 msgstr ""
 
-#: motioneye/templates/main.html:1057
+#: motioneye/templates/main.html:1062
 msgid "Kiam ebligite, kreas specialajn filmojn kaj bildojn, kiuj helpas elpurigi problemojn de moviĝo-detekto."
 msgstr ""
 
-#: motioneye/templates/main.html:1066
+#: motioneye/templates/main.html:1071
 msgid "Ebligu tion se vi volas esti sciigita kiam moviĝo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1067
+#: motioneye/templates/main.html:1072
 msgid "Moviĝaj sciigoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1079
+#: motioneye/templates/main.html:1084
 msgid "Sendi retpoŝton"
 msgstr ""
 
-#: motioneye/templates/main.html:1081
+#: motioneye/templates/main.html:1086
 msgid "Aktivigu ĉi tiun opcion, se vi volas ricevi retpoŝton ĉiufoje kiam moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1084
+#: motioneye/templates/main.html:1089
 msgid "Retpoŝtadresoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1085
+#: motioneye/templates/main.html:1090
 msgid "retpoŝtadresoj…"
 msgstr ""
 
-#: motioneye/templates/main.html:1086
+#: motioneye/templates/main.html:1091
 msgid "Retpoŝtadresoj (apartigitaj per komo) aldonitaj ĉi tie ricevos sciigojn kiam ajn moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1089
+#: motioneye/templates/main.html:1094
 msgid "Servilo SMTP"
 msgstr ""
 
-#: motioneye/templates/main.html:1090
+#: motioneye/templates/main.html:1095
 msgid "ekz. smtp.gmail.com"
 msgstr ""
 
-#: motioneye/templates/main.html:1091
+#: motioneye/templates/main.html:1096
 msgid "Enigu la hostname aŭ IP-adreson de via SMTP-servilo (por uzado de Gmail smtp.gmail.com)."
 msgstr ""
 
-#: motioneye/templates/main.html:1094
+#: motioneye/templates/main.html:1099
 msgid "SMTP Haveno"
 msgstr ""
 
-#: motioneye/templates/main.html:1095
+#: motioneye/templates/main.html:1100
 msgid "ekz. 587"
 msgstr ""
 
-#: motioneye/templates/main.html:1096
+#: motioneye/templates/main.html:1101
 msgid "Eniru la havenon uzatan de via SMTP-servilo (kutime 465 por ne-TLS-ligoj kaj 587 por TLS-ligoj)."
 msgstr ""
 
-#: motioneye/templates/main.html:1099
+#: motioneye/templates/main.html:1104
 msgid "SMTP-Konto"
 msgstr ""
 
-#: motioneye/templates/main.html:1100
+#: motioneye/templates/main.html:1105
 msgid "konto@gmail.com…"
 msgstr ""
 
-#: motioneye/templates/main.html:1101
+#: motioneye/templates/main.html:1106
 msgid "Enigu vian SMTPan konton (kutime via retpoŝta adreso)."
 msgstr ""
 
-#: motioneye/templates/main.html:1104
+#: motioneye/templates/main.html:1109
 msgid "SMTP Pasvorto"
 msgstr ""
 
-#: motioneye/templates/main.html:1106
+#: motioneye/templates/main.html:1111
 msgid "Enigu vian SMTPan pasvorton (por Gmail uzu vian Google-pasvorton aŭ app-specifan generitan pasvorton)."
 msgstr ""
 
-#: motioneye/templates/main.html:1109
+#: motioneye/templates/main.html:1114
 msgid "De adreso"
 msgstr ""
 
-#: motioneye/templates/main.html:1110
+#: motioneye/templates/main.html:1115
 msgid "retpoŝta adreso…"
 msgstr ""
 
-#: motioneye/templates/main.html:1111
+#: motioneye/templates/main.html:1116
 msgid "Agordi kutimon De adreso, se via SMTP-servo postulas unu (la unua destina retpoŝta adreso estos uzata se lasita malplena)."
 msgstr ""
 
-#: motioneye/templates/main.html:1114
+#: motioneye/templates/main.html:1119
 msgid "Uzi TLS"
 msgstr ""
 
-#: motioneye/templates/main.html:1116
+#: motioneye/templates/main.html:1121
 msgid "Ebligu tion, se via SMTP-servilo postulas TLS (Gmail bezonas ĉi tion por ebligi)."
 msgstr ""
 
-#: motioneye/templates/main.html:1119
+#: motioneye/templates/main.html:1124
 msgid "Aldonitaj bildoj tempo-intervalo"
 msgstr ""
 
-#: motioneye/templates/main.html:1121
+#: motioneye/templates/main.html:1126
 msgid "Difinas la tempo-serĉan intervalon por uzi dum kreado de retpoŝtaj ligiloj (pli altaj valoroj generas retpoŝtojn kun pli da bildoj koste de pliigita prokrasta sciigo); agordi al 0 por malebligi aldonitabildojn; vi ankaŭ devas rajtigi «Kaptitaj bildoj» por ke ĉi tio funkciu."
 msgstr ""
 
-#: motioneye/templates/main.html:1125
+#: motioneye/templates/main.html:1130
 msgid "Testi retpoŝto"
 msgstr ""
 
-#: motioneye/templates/main.html:1126
+#: motioneye/templates/main.html:1131
 msgid "Alklaku ĉi tiun butonon por testi retpoŝtajn sciigojn post kiam vi plenigis la postulatajn detalojn."
 msgstr ""
 
-#: motioneye/templates/main.html:1132
+#: motioneye/templates/main.html:1137
 msgid "Sendu Telegraman Sciigon"
 msgstr ""
 
-#: motioneye/templates/main.html:1134
+#: motioneye/templates/main.html:1139
 msgid "ebligu tion se vi volas ricevi telegraman mesaĝon kiam ajn moviĝa evento estas detektita"
 msgstr ""
 
-#: motioneye/templates/main.html:1137
+#: motioneye/templates/main.html:1142
 msgid "HTTP API ĵetono"
 msgstr ""
 
-#: motioneye/templates/main.html:1138
+#: motioneye/templates/main.html:1143
 msgid "Ekzemplo: 93847672:AACdSn843hsjJsh32bSmdN3sHsh2bsh0xRs_32dbcr1W"
 msgstr ""
 
-#: motioneye/templates/main.html:1139
+#: motioneye/templates/main.html:1144
 msgid "Kreante la telegram-bot-babilejon, vi ricevos API-ĵetonon, kiun vi devas enigi ĉi tie. Alklaku la API-butonon sube por paŝo-post-paŝa gvidilo pri kiel akiri vian API-ĵetonon. Ankaŭ nepre babili kun via lastatempe kreita «bot» post kiam via ŝlosilo estas generita, por certigi, ke vi ricevas mesaĝojn."
 msgstr ""
 
-#: motioneye/templates/main.html:1142
+#: motioneye/templates/main.html:1147
 msgid "Babileja ID"
 msgstr ""
 
-#: motioneye/templates/main.html:1143
+#: motioneye/templates/main.html:1148
 msgid "Ekzemplo: 938272312"
 msgstr ""
 
-#: motioneye/templates/main.html:1144
+#: motioneye/templates/main.html:1149
 msgid "Kreu novan babilejon al id_chatbot (@id_chatbot) kaj elektu starti. La babilejo redonos la necesan numeron por ĉi tiu kampo."
 msgstr ""
 
-#: motioneye/templates/main.html:1147
+#: motioneye/templates/main.html:1152
 msgid "Alkroĉitaj Bildoj Tempo"
 msgstr ""
 
-#: motioneye/templates/main.html:1149
+#: motioneye/templates/main.html:1154
 msgid "difinas la bildan serĉtempan intervalon por krei telegramajn aldonojn (pli altaj valoroj generas pli da bildoj koste de pliigita sciiga prokrasto); agordi al 0 por malebligi bildajn aldonaĵojn; vi devas ankaŭ ebligi Senmovajn Bildojn por ke ĉi tio funkciu; vi volos ludi per ĉi tiu numero ĝis bildo estos sendita. Bona komenca numero estas 30 se vi agordas senmovajn bildojn al unu bildmoviĝo ekigita. Por norma movado ekigita, starigu ĉi tion multe pli malalte."
 msgstr ""
 
-#: motioneye/templates/main.html:1152
+#: motioneye/templates/main.html:1157
 msgid "API-Informoj"
 msgstr ""
 
-#: motioneye/templates/main.html:1153
+#: motioneye/templates/main.html:1158
 msgid "Testo"
 msgstr ""
 
-#: motioneye/templates/main.html:1159 motioneye/templates/main.html:1204
+#: motioneye/templates/main.html:1164 motioneye/templates/main.html:1209
 msgid "Alvoki URL"
 msgstr ""
 
-#: motioneye/templates/main.html:1161
+#: motioneye/templates/main.html:1166
 msgid "Ebligu ĉi tion, se vi volas, ke URL estu petata kiam ajn moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1165
+#: motioneye/templates/main.html:1170
 msgid "ekz. http://ekzemplo.com/sciigi/"
 msgstr ""
 
-#: motioneye/templates/main.html:1166
+#: motioneye/templates/main.html:1171
 msgid "URL por esti petita kiam moviĝo estas detektita; la sekvaj specialaj ŝparvojoj estas akceptitaj: %Y = jaro, %m = monato, %d = tago, %H = horo, %M = minuto, %S = sekundo, %q = kadro-numero, %v = okaza numero"
 msgstr ""
 
-#: motioneye/templates/main.html:1178 motioneye/templates/main.html:1223
+#: motioneye/templates/main.html:1183 motioneye/templates/main.html:1228
 msgid "La HTTP-metodo por uzi kiam vi petas URL (la donitaj URL-parametroj estos transdonitaj kiel indikite ĉi tie)."
 msgstr ""
 
-#: motioneye/templates/main.html:1184 motioneye/templates/main.html:1229
+#: motioneye/templates/main.html:1189 motioneye/templates/main.html:1234
 msgid "Lanĉi komando"
 msgstr ""
 
-#: motioneye/templates/main.html:1186
+#: motioneye/templates/main.html:1191
 msgid "Ebligu ĉi tion, se vi volas lanĉi komandon ĉiufoje kiam moviĝokazaĵo estas detektita."
 msgstr ""
 
-#: motioneye/templates/main.html:1189 motioneye/templates/main.html:1234
+#: motioneye/templates/main.html:1194 motioneye/templates/main.html:1239
 msgid "Komando"
 msgstr ""
 
-#: motioneye/templates/main.html:1190 motioneye/templates/main.html:1235
+#: motioneye/templates/main.html:1195 motioneye/templates/main.html:1240
 msgid "komando…"
 msgstr ""
 
-#: motioneye/templates/main.html:1191
+#: motioneye/templates/main.html:1196
 msgid "Komando por esti lanĉa kiam moviĝo estas detektita; multnombraj komandoj povas esti apartigitaj per dupunkto; ne uzu punktokomojn per komandoj; la sekvaj specialaj tokensoj estas akceptitaj: %Y = jaro, %m = monato, %d = tago, %H = horo, %M = minuto, %S = sekundo, %q = kadro-numero, %v = okaza numero"
 msgstr ""
 
-#: motioneye/templates/main.html:1231
+#: motioneye/templates/main.html:1236
 msgid "Ebligu ĉi tion, se vi volas lanĉi komandon ĉiufoje kiam movada evento finiĝos."
 msgstr ""
 
-#: motioneye/templates/main.html:1236
+#: motioneye/templates/main.html:1241
 msgid "Komando por esti lanĉa kiam moviĝokazaĵo finiĝas; multnombraj komandoj povas esti apartigitaj per dupunkto; ne uzu punktokompojn per komandoj; la sekvaj specialaj tokensoj estas akceptitaj: %Y = jaro, %m = monato, %d = dato, %H = horo, %M = minuto, %S = sekundo, %q = kadra nombro."
 msgstr ""
 
-#: motioneye/templates/main.html:1246
+#: motioneye/templates/main.html:1251
 msgid "Ebligu ĉi tion, se vi volas difini ĉiusemajnan horaron por detekto de moviĝo."
 msgstr ""
 
-#: motioneye/templates/main.html:1247
+#: motioneye/templates/main.html:1252
 msgid "Laboranta horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1252
+#: motioneye/templates/main.html:1257
 msgid "Lundo"
 msgstr ""
 
-#: motioneye/templates/main.html:1255 motioneye/templates/main.html:1264
-#: motioneye/templates/main.html:1273 motioneye/templates/main.html:1282
-#: motioneye/templates/main.html:1291 motioneye/templates/main.html:1300
-#: motioneye/templates/main.html:1309
+#: motioneye/templates/main.html:1260 motioneye/templates/main.html:1269
+#: motioneye/templates/main.html:1278 motioneye/templates/main.html:1287
+#: motioneye/templates/main.html:1296 motioneye/templates/main.html:1305
+#: motioneye/templates/main.html:1314
 msgid "de"
 msgstr ""
 
-#: motioneye/templates/main.html:1256 motioneye/templates/main.html:1265
-#: motioneye/templates/main.html:1274 motioneye/templates/main.html:1283
-#: motioneye/templates/main.html:1292 motioneye/templates/main.html:1301
-#: motioneye/templates/main.html:1310
+#: motioneye/templates/main.html:1261 motioneye/templates/main.html:1270
+#: motioneye/templates/main.html:1279 motioneye/templates/main.html:1288
+#: motioneye/templates/main.html:1297 motioneye/templates/main.html:1306
+#: motioneye/templates/main.html:1315
 msgid "ĝis"
 msgstr ""
 
-#: motioneye/templates/main.html:1258
+#: motioneye/templates/main.html:1263
 msgid "Fiksas la labortagan tempintervalon por lundoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1261
+#: motioneye/templates/main.html:1266
 msgid "Mardo"
 msgstr ""
 
-#: motioneye/templates/main.html:1267
+#: motioneye/templates/main.html:1272
 msgid "Fiksas la labortagan tempintervalon por mardoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1270
+#: motioneye/templates/main.html:1275
 msgid "Merkredo"
 msgstr ""
 
-#: motioneye/templates/main.html:1276
+#: motioneye/templates/main.html:1281
 msgid "Fiksas la labortagan tempintervalon por merkredoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1279
+#: motioneye/templates/main.html:1284
 msgid "Ĵaŭdo"
 msgstr ""
 
-#: motioneye/templates/main.html:1285
+#: motioneye/templates/main.html:1290
 msgid "Fiksas la labortagan tempintervalon por ĵaŭdoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1288
+#: motioneye/templates/main.html:1293
 msgid "Vendredo"
 msgstr ""
 
-#: motioneye/templates/main.html:1294
+#: motioneye/templates/main.html:1299
 msgid "Fiksas la labortagan tempintervalon por vendredoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1297
+#: motioneye/templates/main.html:1302
 msgid "Sabato"
 msgstr ""
 
-#: motioneye/templates/main.html:1303
+#: motioneye/templates/main.html:1308
 msgid "Fiksas la labortagan tempintervalon por sabatoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1306
+#: motioneye/templates/main.html:1311
 msgid "Dimanĉo"
 msgstr ""
 
-#: motioneye/templates/main.html:1312
+#: motioneye/templates/main.html:1317
 msgid "Fiksas la labortagan tempintervalon por dimanĉoj."
 msgstr ""
 
-#: motioneye/templates/main.html:1315
+#: motioneye/templates/main.html:1320
 msgid "Detekti movadon"
 msgstr ""
 
-#: motioneye/templates/main.html:1318
+#: motioneye/templates/main.html:1323
 msgid "Dum laborista horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1319
+#: motioneye/templates/main.html:1324
 msgid "Ekster laborista horaro"
 msgstr ""
 
-#: motioneye/templates/main.html:1322
+#: motioneye/templates/main.html:1327
 msgid "Difinas, ĉu moviĝodetekto devas esti aktiva dum aŭ ekster la laborista horaro."
 msgstr ""
 

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:954
+#: motioneye/config.py:956
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:958
+#: motioneye/config.py:960
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %I %p %l %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:963
+#: motioneye/config.py:965
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:968
+#: motioneye/config.py:970
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:973
+#: motioneye/config.py:975
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:956
+#: motioneye/config.py:954
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:960
+#: motioneye/config.py:958
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %I %p %l %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:965
+#: motioneye/config.py:963
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:970
+#: motioneye/config.py:968
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:975
+#: motioneye/config.py:973
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 


### PR DESCRIPTION
The keepalive and tolerant_check netcam_params were stored in the internal dictionary as unmodified on/off strings. When stored back to the config, the tolerant_check string value is trusty, hence always set to "on", even if the value was "off" before. Since the keepalive value can be "force" as well, its boolean values are checked explicitly, else the string was stored unmodified, preserving the original value, however, more as an accidental side effect than intentional. Only the rtsp_transport parameter was explicitly converted into a boolean when parsed, and hence stored back as intended on/off value.

This bug was rarely recognized, since motionEye sets netcam_tolerant_check to True as hardcoded value when a netcam is added, and there is no GUI toggle for this. And these parameters are checked nowhere else in the code where their false type would cause an error or unexpected behavior.

This commit does the intended on/off to bool conversion, to assure any custom config changes are preserved, and any potentially added code that relies on expected types will work. Strict typing is added to the respective functions, and the motion default is assigned if the config value is invalid.