### PR TITLE
fix(config): add "pause" to used motion options

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -107,6 +107,7 @@ _USED_MOTION_OPTIONS = {
     'on_event_start',
     'on_movie_end',
     'on_picture_save',
+    'pause',
     'picture_filename',
     'picture_output_motion',
     'picture_output',

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:954
+#: motioneye/config.py:955
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:958
+#: motioneye/config.py:959
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %I %p %l %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:963
+#: motioneye/config.py:964
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:968
+#: motioneye/config.py:969
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:973
+#: motioneye/config.py:974
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 


### PR DESCRIPTION
It was added for motion >= 4.4 as replacement for the API call, to disable motion detection. Options not listed in _USED_MOTION_OPTIONS are however shown in the extra options box of the GUI, which can be confusing. Make it a known option, as it will be always set explicitly if supported by the motion version.