### PR TITLE
Filter config listing by user role

### DIFF
--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -45,6 +45,30 @@ __all__ = ('ConfigHandler',)
 
 
 class ConfigHandler(BaseHandler):
+    # fields visible to the normal/surveillance user
+    _NON_ADMIN_CAMERA_FIELDS = frozenset(
+        {
+            'id',
+            'name',
+            'enabled',
+            'proto',
+            'actions',
+            'streaming_framerate',
+            'streaming_server_resize',
+            'url',  # only for simple mjpeg cameras
+        }
+    )
+
+    def _sanitize_camera_on_usertype(self, camera: dict) -> dict:
+        if self.current_user in ['admin', 'peer']:
+            return camera
+
+        return {
+            key: value
+            for key, value in camera.items()
+            if key in self._NON_ADMIN_CAMERA_FIELDS
+        }
+
     async def get(self, camera_id=None, op=None):
         config.invalidate_monitor_commands()
 
@@ -440,18 +464,20 @@ class ConfigHandler(BaseHandler):
         if resp.error:
             msg = f'Failed to get remote camera configuration for {remote.pretty_camera_url(local_config)}: {resp.error}.'
             cameras.append(
-                {
-                    'id': camera_id,
-                    'name': f'Camera {camera_id} - Connection failed',
-                    'enabled': False,
-                    'connection_failed': True,
-                    'connection_error': msg,
-                    'connection_url': remote.pretty_camera_url(
-                        local_config, camera=False
-                    ),
-                    'streaming_framerate': 1,
-                    'framerate': 1,
-                }
+                self._sanitize_camera_on_usertype(
+                    {
+                        'id': camera_id,
+                        'name': f'Camera {camera_id} - Connection failed',
+                        'enabled': False,
+                        'connection_failed': True,
+                        'connection_error': msg,
+                        'connection_url': remote.pretty_camera_url(
+                            local_config, camera=False
+                        ),
+                        'streaming_framerate': 1,
+                        'framerate': 1,
+                    }
+                )
             )
 
         else:
@@ -481,7 +507,7 @@ class ConfigHandler(BaseHandler):
                     continue
                 resp.remote_ui_config[key.replace('@', '')] = value
 
-            cameras.append(resp.remote_ui_config)
+            cameras.append(self._sanitize_camera_on_usertype(resp.remote_ui_config))
 
         self.check_finished(cameras, length)
 
@@ -587,7 +613,7 @@ class ConfigHandler(BaseHandler):
 
                 if utils.is_local_motion_camera(local_config):
                     ui_config = config.motion_camera_dict_to_ui(local_config)
-                    cameras.append(ui_config)
+                    cameras.append(self._sanitize_camera_on_usertype(ui_config))
                     if self.check_finished(cameras, length):
                         return
 
@@ -614,7 +640,7 @@ class ConfigHandler(BaseHandler):
 
                 else:  # assuming simple mjpeg camera
                     ui_config = config.simple_mjpeg_camera_dict_to_ui(local_config)
-                    cameras.append(ui_config)
+                    cameras.append(self._sanitize_camera_on_usertype(ui_config))
                     if self.check_finished(cameras, length):
                         return
 

--- a/motioneye/handlers/config.py
+++ b/motioneye/handlers/config.py
@@ -464,20 +464,18 @@ class ConfigHandler(BaseHandler):
         if resp.error:
             msg = f'Failed to get remote camera configuration for {remote.pretty_camera_url(local_config)}: {resp.error}.'
             cameras.append(
-                self._sanitize_camera_on_usertype(
-                    {
-                        'id': camera_id,
-                        'name': f'Camera {camera_id} - Connection failed',
-                        'enabled': False,
-                        'connection_failed': True,
-                        'connection_error': msg,
-                        'connection_url': remote.pretty_camera_url(
-                            local_config, camera=False
-                        ),
-                        'streaming_framerate': 1,
-                        'framerate': 1,
-                    }
-                )
+                {
+                    'id': camera_id,
+                    'name': f'Camera {camera_id} - Connection failed',
+                    'enabled': False,
+                    'connection_failed': True,
+                    'connection_error': msg,
+                    'connection_url': remote.pretty_camera_url(
+                        local_config, camera=False
+                    ),
+                    'streaming_framerate': 1,
+                    'framerate': 1,
+                }
             )
 
         else:

--- a/tests/test_handlers/test_config_list.py
+++ b/tests/test_handlers/test_config_list.py
@@ -1,0 +1,114 @@
+from json import loads
+from unittest.mock import patch
+
+import tornado.testing
+
+from motioneye.handlers.config import ConfigHandler
+from tests.test_handlers import HandlerTestCase
+
+# a fake motion_camera_dict_to_ui() result that mixes viewer and admin-only fields
+_FAKE_UI_CONFIG = {
+    'id': 1,
+    'name': 'test',
+    'enabled': True,
+    'proto': 'v4l2',
+    'actions': ['snapshot'],
+    'streaming_framerate': 25,
+    'streaming_server_resize': False,
+    'admin_only': False,
+    'device_url': '/dev/video0',
+    'network_username': 'secretuser',
+    'network_password': 'secretpass',
+    'upload_username': 'uploaduser',
+    'upload_password': 'uploadpass',
+    'upload_access_key': 'AKIAEXAMPLE',
+    'upload_secret_key': 'shh-its-secret',
+}
+
+_SENSITIVE_FIELDS = (
+    'admin_only',
+    'device_url',
+    'network_username',
+    'network_password',
+    'upload_username',
+    'upload_password',
+    'upload_access_key',
+    'upload_secret_key',
+)
+
+_PUBLIC_FIELDS = (
+    'id',
+    'name',
+    'enabled',
+    'proto',
+    'actions',
+    'streaming_framerate',
+    'streaming_server_resize',
+)
+
+
+class ConfigListHandlerTest(HandlerTestCase):
+    handler_cls = ConfigHandler
+
+    def setUp(self):
+        super().setUp()
+        self._extra_patches = [
+            patch('motioneye.config.get_main', return_value={'@enabled': True}),
+            patch('motioneye.utils.is_local_motion_camera', return_value=True),
+            patch(
+                'motioneye.config.motion_camera_dict_to_ui',
+                return_value=dict(_FAKE_UI_CONFIG),
+            ),
+        ]
+        for p in self._extra_patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._extra_patches:
+            p.stop()
+        super().tearDown()
+
+    def test_normal_user_does_not_get_admin_fields(self):
+        cookie = self.make_session_cookie('normal')
+        response = self.fetch('/config/list/', headers={'Cookie': cookie})
+        self.assertEqual(200, response.code)
+
+        cameras = loads(response.body)['cameras']
+        self.assertEqual(1, len(cameras))
+        camera = cameras[0]
+
+        for field in _SENSITIVE_FIELDS:
+            self.assertNotIn(field, camera)
+
+        for field in _PUBLIC_FIELDS:
+            self.assertIn(field, camera)
+
+    def test_admin_gets_full_config(self):
+        cookie = self.make_session_cookie('admin')
+        response = self.fetch('/config/list/', headers={'Cookie': cookie})
+        self.assertEqual(200, response.code)
+
+        cameras = loads(response.body)['cameras']
+        camera = cameras[0]
+
+        for field in _SENSITIVE_FIELDS:
+            self.assertIn(field, camera)
+
+    def test_sanitize_camera_on_usertype_keeps_full_config_for_peer(self):
+        handler = self.get_handler()
+        handler._current_user = 'peer'
+        camera = handler._sanitize_camera_on_usertype(dict(_FAKE_UI_CONFIG))
+        self.assertEqual(_FAKE_UI_CONFIG, camera)
+
+    def test_sanitize_camera_on_usertype_strips_for_normal(self):
+        handler = self.get_handler()
+        handler._current_user = 'normal'
+        camera = handler._sanitize_camera_on_usertype(dict(_FAKE_UI_CONFIG))
+        for field in _SENSITIVE_FIELDS:
+            self.assertNotIn(field, camera)
+        for field in _PUBLIC_FIELDS:
+            self.assertIn(field, camera)
+
+
+if __name__ == '__main__':
+    tornado.testing.main()


### PR DESCRIPTION
- Add an explicit whitelist of camera fields for normal users.
- Apply the whitelist to local, remote, and simple MJPEG camera entries.
- Add tests covering normal, admin, and peer user types.