### PR TITLE
fix for v4l2 cameras: show bool controls and fix control name mismatch with Motion

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1120,9 +1120,12 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         threshold = int(float(ui['frame_change_threshold']) * width * height / 100)
 
         if proto == 'v4l2':
-            # video controls
+            # video controls, control_id is the ID Motion actually matches against (see v4l2-ctl --list-ctrls)
+            video_controls = v4l2ctl.list_ctrls(prev_config.get('videodevice', ''))
             vid_control_params = (
-                ('{}={}'.format(n, c['value']))
+                '{}={}'.format(
+                    video_controls.get(n, {}).get('control_id', n), c['value']
+                )
                 for n, c in list(ui['video_controls'].items())
             )
             data['vid_control_params'] = ','.join(vid_control_params)
@@ -1682,6 +1685,12 @@ def motion_camera_dict_to_ui(data):  # noqa: C901
         ui['resolution'] = str(data['width']) + 'x' + str(data['height'])
 
         video_controls = v4l2ctl.list_ctrls(data['videodevice'])
+
+        # video_params is keyed by control_id, map it back to our UI name
+        name_by_control_id = {
+            c.get('control_id', n): n for n, c in video_controls.items()
+        }
+
         video_controls = [
             (n, c)
             for (n, c) in list(video_controls.items())
@@ -1701,6 +1710,7 @@ def motion_camera_dict_to_ui(data):  # noqa: C901
             else:
                 continue  # ignore any other kind of param
 
+            name = name_by_control_id.get(name, name)
             vid_control_values[name] = value
 
         ui['video_controls'] = {

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1122,13 +1122,14 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
         if proto == 'v4l2':
             # video controls, control_id is the ID Motion actually matches against (see v4l2-ctl --list-ctrls)
             video_controls = v4l2ctl.list_ctrls(prev_config.get('videodevice', ''))
-            vid_control_params = (
-                '{}={}'.format(
-                    video_controls.get(n, {}).get('control_id', n), c['value']
+            if video_controls:
+                vid_control_params = (
+                    '{}={}'.format(
+                        video_controls.get(n, {}).get('control_id', n), c['value']
+                    )
+                    for n, c in list(ui['video_controls'].items())
                 )
-                for n, c in list(ui['video_controls'].items())
-            )
-            data['vid_control_params'] = ','.join(vid_control_params)
+                data['vid_control_params'] = ','.join(vid_control_params)
 
     else:  # assuming netcam
         if match(

--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -195,7 +195,13 @@ def list_ctrls(device):
         # Motion matches controls by ID. We use ID because the driver's raw
         # name doesn't always match the name v4l2-ctl gives (e.g. driver:
         # "White Balance, Automatic" vs. v4l2-ctl: "white_balance_automatic")
-        properties['control_id'] = f'ID{int(id_hex, 16):08d}'
+        if id_hex:
+            try:
+                properties['control_id'] = f'ID{int(id_hex, 16):08d}'
+            except ValueError:
+                logging.warning(
+                    f'could not parse v4l2 control id "{id_hex}" for "{control}"'
+                )
 
         controls[control] = properties
 

--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -179,14 +179,18 @@ def list_ctrls(device):
         if not line:
             continue
 
-        match = re.match(r'^\s*(\w+)\s+([a-f0-9x\s]+)?\(\w+\)\s*:\s*(.+)\s*', line)
+        match = re.match(r'^\s*(\w+)\s+([a-f0-9x\s]+)?\((\w+)\)\s*:\s*(.+)\s*', line)
         if not match:
             continue
 
-        control, _, properties = match.groups()
+        control, _, ctrl_type, properties = match.groups()
         properties = dict(
             [v.split('=', 1) for v in properties.split(' ') if v.count('=')]
         )
+        if ctrl_type == 'bool':
+            # v4l2-ctl --list-ctrls gives no min/max for bool controls, so set them here
+            properties.setdefault('min', '0')
+            properties.setdefault('max', '1')
         controls[control] = properties
 
     _ctrls_cache[device] = controls

--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -183,7 +183,7 @@ def list_ctrls(device):
         if not match:
             continue
 
-        control, _, ctrl_type, properties = match.groups()
+        control, id_hex, ctrl_type, properties = match.groups()
         properties = dict(
             [v.split('=', 1) for v in properties.split(' ') if v.count('=')]
         )
@@ -191,6 +191,12 @@ def list_ctrls(device):
             # v4l2-ctl --list-ctrls gives no min/max for bool controls, so set them here
             properties.setdefault('min', '0')
             properties.setdefault('max', '1')
+
+        # Motion matches controls by ID. We use ID because the driver's raw
+        # name doesn't always match the name v4l2-ctl gives (e.g. driver:
+        # "White Balance, Automatic" vs. v4l2-ctl: "white_balance_automatic")
+        properties['control_id'] = f'ID{int(id_hex, 16):08d}'
+
         controls[control] = properties
 
     _ctrls_cache[device] = controls


### PR DESCRIPTION
`v4l2-ctl --list-ctrls` reports boolean controls, such as `white_balance_automatic`, without `min`, `max`, or `step` properties. Integer controls usually include these properties, as shown below.

`list_ctrls()` already matched the parenthesized control type, but did not capture or use it. Downstream, `config.py` filters out controls without min and max properties, while the frontend renders controls with `min == 0 && max == 1` as checkboxes instead of range sliders.

Capture the V4L2 control type and default bool controls to `min=0` and `max=1`, allowing them to pass through the existing filter and render as checkboxes (just like was already done for `int` control options with only two states, such as `backlight_compensation` below).

Example `v4l2-ctl --list-ctrls`:
```
User Controls

                     brightness 0x00980900 (int)    : min=-64 max=64 step=1 default=0 value=0
                       contrast 0x00980901 (int)    : min=0 max=100 step=1 default=50 value=50
                     saturation 0x00980902 (int)    : min=0 max=100 step=1 default=64 value=64
                            hue 0x00980903 (int)    : min=-180 max=180 step=1 default=0 value=0
        white_balance_automatic 0x0098090c (bool)   : default=1 value=1  <---
                          gamma 0x00980910 (int)    : min=100 max=500 step=1 default=300 value=300
           power_line_frequency 0x00980918 (menu)   : min=0 max=2 default=1 value=1 (50 Hz)
      white_balance_temperature 0x0098091a (int)    : min=2800 max=6500 step=10 default=4600 value=4600 flags=inactive
                      sharpness 0x0098091b (int)    : min=0 max=100 step=1 default=50 value=50
         backlight_compensation 0x0098091c (int)    : min=0 max=1 step=1 default=0 value=0

Camera Controls

                  auto_exposure 0x009a0901 (menu)   : min=0 max=3 default=3 value=3 (Aperture Priority Mode)
         exposure_time_absolute 0x009a0902 (int)    : min=50 max=10000 step=1 default=166 value=166 flags=inactive
     exposure_dynamic_framerate 0x009a0903 (bool)   : default=0 value=1  <---
```
#
Also, many controls never actually reached the camera. Motion matches `video_params` entries against the control's raw driver name (as returned by `VIDIOC_QUERYCTRL`), not the name `v4l2-ctl` shows (used by motionEye). For controls with a multi-word name, these two differ: the driver reports `"White Balance, Automatic"`, while `v4l2-ctl` normalizes that to `white_balance_automatic`. Motion's name comparison doesn't account for this, so it silently never applied the setting without an error, the value just never changed beyond the config.

Single-word controls (`brightness`, `contrast`, ...) happened to still work, since there's nothing to normalize, which is likely why this went unnoticed for so long.

Instead of the name, write the control's numeric ID, the same [ID%08d](https://github.com/Motion-Project/motion/blob/release-4.7.1/src/video_v4l2.c#L240) format Motion itself uses internally (`ctrl_iddesc` in `video_v4l2.c`) to identify a control regardless of its name (and is listed in the motion documentation: https://motion-project.github.io/motion_config.html#video_params). This matches unambiguously, whatever the driver calls the control. (and was just the easiest fix 😅)

Old (name-based, silently ignored by Motion for multi-word names):

    video_params white_balance_automatic=0,brightness=30,exposure_dynamic_framerate=1

New (ID-based, always matches):

    video_params ID09963788=0,ID09963776=30,ID10094851=1
