### PR TITLE
chore: address some more code quality findings

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -434,7 +434,7 @@ def set_main(main_config):
         f.close()
 
 
-def get_camera_ids(filter_valid=True):
+def get_camera_ids():
     global _camera_ids_cache
 
     if _camera_ids_cache is not None:
@@ -464,9 +464,6 @@ def get_camera_ids(filter_valid=True):
             camera_ids.append(camera_id)
 
     camera_ids.sort()
-
-    if not filter_valid:
-        return camera_ids
 
     filtered_camera_ids = []
     for camera_id in camera_ids:

--- a/motioneye/handlers/action.py
+++ b/motioneye/handlers/action.py
@@ -32,12 +32,13 @@ __all__ = ('ActionHandler',)
 class ActionHandler(BaseHandler):
     @BaseHandler.auth()
     @BaseHandler.peer_allowed()
-    async def post(self, camera_id, action):
+    async def post(self, camera_id, action) -> None:
         camera_id = int(camera_id)
         if camera_id not in config.get_camera_ids():
             raise HTTPError(404, 'no such camera')
 
-        local_config = config.get_camera(camera_id)
+        local_config: dict = config.get_camera(camera_id)
+
         # block access to admin-only cameras for non-admin users
         if (
             local_config
@@ -48,35 +49,39 @@ class ActionHandler(BaseHandler):
                 403,
                 f'access denied to admin-only camera "{camera_id}" for action "{action}"',
             )
+
         if utils.is_remote_camera(local_config):
             resp = await remote.exec_action(local_config, action)
             if resp.error:
                 msg = (
-                    'Failed to execute action on remote camera at {url}: {msg}.'.format(
-                        url=remote.pretty_camera_url(local_config), msg=resp.error
-                    )
+                    'Failed to execute action on remote camera at '
+                    f'{remote.pretty_camera_url(local_config)}: {resp.error}.'
                 )
+                self.finish_json({'error': msg})
 
-                return self.finish_json({'error': msg})
+            else:
+                self.finish_json()
 
-            return self.finish_json()
+            return
 
         if action == 'snapshot':
-            logging.debug('executing snapshot action for camera with id %s' % camera_id)
+            logging.debug(f'executing snapshot action for camera with id {camera_id}')
             await self.snapshot(camera_id)
             return
 
         elif action == 'record_start':
             logging.debug(
-                'executing record_start action for camera with id %s' % camera_id
+                f'executing record_start action for camera with id {camera_id}'
             )
-            return self.record_start(camera_id)
+            self.record_start(camera_id)
+            return
 
         elif action == 'record_stop':
             logging.debug(
-                'executing record_stop action for camera with id %s' % camera_id
+                f'executing record_stop action for camera with id {camera_id}'
             )
-            return self.record_stop(camera_id)
+            self.record_stop(camera_id)
+            return
 
         action_commands = config.get_action_commands(local_config)
         command = action_commands.get(action)
@@ -87,8 +92,6 @@ class ActionHandler(BaseHandler):
             f'executing {action} action for camera with id {camera_id}: "{command}"'
         )
         self.run_command_bg(command)
-
-        return None
 
     def run_command_bg(self, command):
         self.p = subprocess.Popen(

--- a/motioneye/locale/motioneye.pot
+++ b/motioneye/locale/motioneye.pot
@@ -1,20 +1,20 @@
-#: motioneye/config.py:959
+#: motioneye/config.py:956
 msgid "Device names are only allowed to contain alphanumerical characters, hyphen -, underscore _, plus +, and space"
 msgstr ""
 
-#: motioneye/config.py:963
+#: motioneye/config.py:960
 msgid "File names are only allowed to contain alphanumerical characters, parenthesis (), forward slash /, dot ., underscore _, hyphen -, space, and a subset of motion conversion specifiers: %C %Y %m %d %H %M %S %I %p %l %q %v %$"
 msgstr ""
 
-#: motioneye/config.py:968
+#: motioneye/config.py:965
 msgid "Directory names are only allowed to contain alphanumerical characters, space, parenthesis (), forward slash /, dot ., underscore _, and hyphen -"
 msgstr ""
 
-#: motioneye/config.py:973
+#: motioneye/config.py:970
 msgid "Email addresses are only allowed to contain alphanumerical characters, underscore _, plus +, dot ., at @, caret ^, tilde ~, angle brackets <>, hyphen -, and may be separated by comma, and space"
 msgstr ""
 
-#: motioneye/config.py:978
+#: motioneye/config.py:975
 msgid "URLs are not allowed to contain caret ^, semicolon ;, or apostrophe '"
 msgstr ""
 

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -279,7 +279,6 @@ def build_digest_header(method, url, username, password, state):
     def KD(s, d):
         return hash_utf8(f"{s}:{d}")
 
-    entdig = None
     p_parsed = urllib.parse.urlparse(url)
     path = p_parsed.path
     if p_parsed.query:
@@ -330,8 +329,6 @@ def build_digest_header(method, url, username, password, state):
         base += f', opaque="{opaque}"'
     if algorithm:
         base += f', algorithm="{algorithm}"'
-    if entdig:
-        base += f', digest="{entdig}"'
     if qop:
         base += f', qop=auth, nc={ncvalue}, cnonce="{cnonce}"'
 


### PR DESCRIPTION
Btw, I started addressing (or letting Copilot do so) these now, since code quality findings exited preview stage and are supposed to be billed from now on. However, the scans are still running, nothing is billed yet (0$ limit present and no payment method added anyway, so they would just not run), probably they remain free somewhat longer for public repos/orgas, we'll see.

There is one more finding claiming `_camera_ids_cache` would be unused, which however is not: The function which assigns it uses it as well. Looks like CodeQL fails to recognize this usage on subsequent function calls. Once we drop support for Python <3.9, we can use the `@cache` decorator instead, to cache the response of the whole function, and drop all those global cache variables. This is pretty cool stuff: https://docs.python.org/3/library/functools.html#functools.cache
The functions gain a method to clear the cache, of course.