### PR TITLE
ci: split pip install back into dedicated step

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           python-version: 3.x
           check-latest: true
-          pip-install: pip-audit
+      - run: pip install -U pip-audit
       - run: pip-audit -Sv .

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -19,9 +19,7 @@ jobs:
         python-version: '3.x'
         check-latest: true
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade build twine
+      run: python -m pip install --upgrade setuptools build twine
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -30,11 +30,6 @@ jobs:
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"
     steps:
-      - name: Ubuntu Noble workarounds
-        if: matrix.dist == 'ubuntu-24.04' || matrix.dist == 'ubuntu-24.04-arm'
-        run: |
-          # error: externally-managed-environment
-          echo -e '[global]\nbreak-system-packages=true' | sudo tee /etc/pip.conf
       # ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.
       - run: sudo DEBIAN_FRONTEND='noninteractive' apt-get -qq autopurge python3-pip python3-setuptools python3-wheel
       - run: sudo apt-get -q update
@@ -43,8 +38,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - run: python3 -m pip install --upgrade pip setuptools wheel
-      - run: python3 -m pip install --upgrade build mypy pytest
+      - run: python3 -m pip install --upgrade pip setuptools build mypy pytest
       - run: python3 -m build
       - run: python3 -m pip install .
       - run: mkdir --parents --verbose .mypy_cache

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -18,11 +18,6 @@ jobs:
     runs-on: ${{ matrix.dist }}
     name: "Test on ${{ matrix.dist }}"
     steps:
-      - name: Ubuntu Noble workarounds
-        if: matrix.dist == 'ubuntu-24.04' || matrix.dist == 'ubuntu-24.04-arm'
-        run: |
-          # error: externally-managed-environment
-          echo -e '[global]\nbreak-system-packages=true' | sudo tee /etc/pip.conf
       # ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.
       - run: sudo DEBIAN_FRONTEND="noninteractive" apt-get -qq autopurge python3-pip python3-setuptools python3-wheel python3-dev
       - run: sudo apt-get -q update

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         python-version: '3.x'
         check-latest: true
-        pip-install: babel jinja2
 
-    - name: Install gettext
+    - name: Install dependencies
       run: |
+        pip install -U babel jinja2 &
         sudo apt-get -q update
         sudo DEBIAN_FRONTEND='noninteractive' apt-get -qq --no-install-recommends install gettext
 


### PR DESCRIPTION
`python-setup`'s `pip-install` feature has been removed again.

This also removes the obsolete Ubuntu 24.04 workaround (which has been added to the runner images OOTB) and merges some `pip install` calls.