### PR TITLE
fix(v4l2): warn on a failed control listing and don't cache it (follow-up #3391)

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1131,6 +1131,12 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
                 )
                 data['vid_control_params'] = ','.join(vid_control_params)
 
+            else:
+                logging.warning(
+                    f'camera {prev_config["@id"]} control listing failed, '
+                    'controls not updated'
+                )
+
     else:  # assuming netcam
         if match(
             r'^rtsp|^rtmp', data.get('netcam_url', prev_config.get('netcam_url', ''))

--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -205,6 +205,8 @@ def list_ctrls(device):
 
         controls[control] = properties
 
-    _ctrls_cache[device] = controls
+    # don't cache an empty result, the cache has no expiry
+    if controls:
+        _ctrls_cache[device] = controls
 
     return controls


### PR DESCRIPTION
#3391 leaves `vid_control_params` unchanged when `v4l2ctl.list_ctrls()` comes back empty. Since `list_ctrls()` caches its result, losing the connection alone is not enough to trigger this: the cached control IDs are still used when saving. `if video_controls:` can be false in two cases:

- the lookup returned no controls when the page was loaded and still returns none when saving, so no controls are shown in the UI and the existing config values are kept
- the cache was cleared after the page was loaded and the next lookup returns no controls, so the existing `vid_control_params` are kept instead of falling back to the names submitted by the UI

This PR adds a warning when that happens.

This PR also stops `list_ctrls()` from caching an empty result. The cache has no expiry and is only cleared by `list_devices()`, so a failed lookup was kept until that ran or motionEye restarted, leaving the Video Controls section empty long after the device came back. Skipping the cache write means the next lookup simply tries again.
